### PR TITLE
Removed parsing and desugaring in first pass

### DIFF
--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -20,6 +20,8 @@ part 'ast/event.dart';
 part 'ast/interpolation.dart';
 part 'ast/property.dart';
 part 'ast/text.dart';
+part 'ast/structure.dart';
+part 'ast/banana.dart';
 
 String stringifyAstTree(NgAstNode node, {int indent: 0}) {
   var buffer = new StringBuffer(' ' * indent);

--- a/lib/src/ast/attribute.dart
+++ b/lib/src/ast/attribute.dart
@@ -6,7 +6,8 @@ part of angular2_template_parser.src.ast;
 /// A parsed attribute AST.
 ///
 /// An attribute is static property [name] defined at compile-time that
-/// decorates an [NgElement]. A non-null [value] means the attribute also
+/// decorates an [NgElement] or a directive attached to an element.
+/// A non-null [value] means the attribute also
 /// receives a value, otherwise it is considered standalone.
 class NgAttribute extends NgAstNode with NgAstSourceTokenMixin {
   /// Name of the attribute.

--- a/lib/src/ast/banana.dart
+++ b/lib/src/ast/banana.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+part of angular2_template_parser.src.ast;
+
+/// A parsed binding AST.
+class NgBanana extends NgAstNode with NgAstSourceTokenMixin {
+  /// Name of the binding.
+  final String name;
+
+  /// Value of the binding (Optional).
+  final String value;
+
+  /// Create a new [NgBanana].
+  NgBanana(this.name, this.value) : super._(const []);
+
+  /// Create a new [NgBanana] from tokenized HTML.
+  NgBanana.fromTokens(
+    NgToken before,
+    NgToken start,
+    NgToken name,
+    NgToken equals,
+    NgToken value,
+    NgToken end,
+  )
+      : this.name = name.text,
+        this.value = value.text,
+        super._([before, start, name, equals, value, end]);
+
+  @override
+  int get hashCode => name.hashCode;
+
+  @override
+  bool operator ==(Object o) {
+    if (o is NgBanana) {
+      return o.name == name && o.value == value;
+    }
+    return false;
+  }
+
+  @override
+  String toString() => '$NgBanana [($name)]=$value';
+
+  @override
+  void visit(Visitor visitor) => visitor.visitBanana(this);
+}

--- a/lib/src/ast/structure.dart
+++ b/lib/src/ast/structure.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+part of angular2_template_parser.src.ast;
+
+/// A parsed structural directive AST.
+class NgStructure extends NgAstNode with NgAstSourceTokenMixin {
+  /// Name of the property.
+  final String name;
+
+  /// Value of the property (structural microsyntax).
+  final String value;
+
+  NgStructure(this.name, this.value) : super._(const []);
+
+  NgStructure.fromTokens(
+    NgToken before,
+    NgToken start,
+    NgToken name,
+    NgToken equals,
+    NgToken value,
+    NgToken end,
+  )
+      : this.name = name.text,
+        this.value = value.text,
+        super._([before, start, name, equals, value, end]);
+
+  @override
+  int get hashCode => hash2(name, value);
+
+  @override
+  bool operator ==(Object o) {
+    if (o is NgStructure) {
+      return o.name == name && o.value == value;
+    }
+    return false;
+  }
+
+  @override
+  String toString() => '$NgStructure *$name="$value"';
+
+  @override
+  void visit(Visitor visitor) => visitor.visitStructure(this);
+}

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -4,12 +4,12 @@
 import 'ast.dart';
 import 'lexer.dart';
 import 'errors.dart';
-import 'utils.dart';
+//import 'utils.dart';
 import 'visitor.dart';
 
 import 'package:source_span/src/span.dart';
-import 'package:analyzer/analyzer.dart';
-import 'package:analyzer/dart/ast/token.dart' as analyzer;
+// import 'package:analyzer/analyzer.dart';
+// import 'package:analyzer/dart/ast/token.dart' as analyzer;
 
 // WIP - stll sorting out what is a valid element.
 final RegExp _elementValidator = new RegExp(r'[a-zA-Z][a-zA-Z0-9_\-]+');
@@ -133,12 +133,6 @@ class _ScannerParser extends NgTemplateScanner<NgAstNode> {
     var value = next();
     var end = next();
     var node = new NgEvent.fromTokens(before, start, name, equals, value, end);
-    try {
-      node..expression = parseAngularExpression(value.text, 'event node');
-    } on AnalyzerErrorGroup catch (e) {
-      onError(new InvalidDartExpressionError(value, e));
-      return;
-    }
     addChild(node);
     addAllTokens([before, start, name, equals, value, end]);
   }
@@ -180,14 +174,7 @@ class _ScannerParser extends NgTemplateScanner<NgAstNode> {
     var equals = next();
     var value = next();
     var end = next();
-    var node =
-        new NgProperty.fromTokens(before, start, name, equals, value, end);
-    try {
-      node..expression = parseAngularExpression(value.text, 'property node');
-    } on AnalyzerErrorGroup catch (e) {
-      onError(new InvalidDartExpressionError(value, e));
-      return;
-    }
+    var node = new NgProperty.fromTokens(before, start, name, equals, value, end);
     addChild(node);
     addAllTokens([before, start, name, equals, value, end]);
   }
@@ -197,13 +184,6 @@ class _ScannerParser extends NgTemplateScanner<NgAstNode> {
     var value = next();
     var end = next();
     var node = new NgInterpolation.fromTokens(start, value, end);
-    try {
-      node
-        ..expression = parseAngularExpression(value.text, 'interpolation node');
-    } on AnalyzerErrorGroup catch (e) {
-      onError(new InvalidDartExpressionError(value, e));
-      return;
-    }
     addChild(node);
   }
 
@@ -214,72 +194,22 @@ class _ScannerParser extends NgTemplateScanner<NgAstNode> {
 
   @override
   void scanBanana(NgToken before, NgToken start) {
-    const String location = 'bananan (in a box)';
     var name = next();
     var equals = next();
     var value = next();
     var end = next();
-    Expression expression;
-    try {
-      expression = parseAngularExpression(value.text, location);
-      if (expression.beginToken.type != analyzer.TokenType.IDENTIFIER ||
-          expression.beginToken != expression.endToken) {
-        onError(new BananaLimitedIdentifierError(value));
-        return;
-      }
-    } on AnalyzerErrorGroup catch (e) {
-      onError(new InvalidDartExpressionError(value, e));
-      return;
-    }
-    addChild(new NgProperty.fromTokens(before, start, name, equals, value, end)
-      ..expression = expression);
-    // In theory, this second parse should never fail provided the first
-    // is only an identifier.
-    addChild(new NgEvent.fromBanana(before, start, name, equals, value, end)
-      ..expression =
-          parseAngularExpression('${value.text} = \$event', location));
+    addChild(new NgBanana.fromTokens(before, start, name, equals, value, end));
     addAllTokens([before, start, name, equals, value, end]);
   }
 
   @override
   void scanStructural(NgToken before, NgToken start) {
-    // The element that the structural directive will exist on.
-    final NgElement element = peek();
-
     // Parse all of the tokens that make up the structual directive.
     var name = next();
     var equals = next();
     var value = next();
     var end = next();
-    var old = pop();
-
-    // will this work in general?  what about duplicate tags?
-    final idx = peek().childNodes.lastIndexOf(old);
-
-    // if the index is -1, then we have already added a structural tag.
-    if (idx == -1) {
-      final NgProperty firstDirective =
-          peek().childNodes.first.childNodes.first;
-      onError(
-        new ExtraStructuralDirectiveError(
-          element,
-          start,
-          name,
-          value,
-          firstDirective.parsedTokens[2],
-          firstDirective.parsedTokens[4],
-        ),
-      );
-      push(old);
-      return;
-    }
-    peek().childNodes.removeAt(idx);
-    var newOld = new NgElement.unknown('template', childNodes: [
-      new NgProperty.fromTokens(before, start, name, equals, value, end),
-      old
-    ]);
-    addChild(newOld);
-    push(old);
+    addChild(new NgStructure.fromTokens(before, start, name, equals, value, end));
     addAllTokens([before, start, name, equals, value, end]);
   }
 

--- a/lib/src/visitor.dart
+++ b/lib/src/visitor.dart
@@ -29,4 +29,8 @@ abstract class Visitor {
   void visitEvent(NgEvent node);
 
   void visitText(NgText node);
+
+  void visitStructure(NgStructure node);
+
+  void visitBanana(NgBanana node);
 }

--- a/lib/src/visitor/unparser.dart
+++ b/lib/src/visitor/unparser.dart
@@ -93,5 +93,15 @@ class Unparser implements Visitor {
   }
 
   @override
+  void visitStructure(NgStructure node) {
+    _buffer.write(' *${node.name}="${node.value}"');
+  }
+
+  @override
+  void visitBanana(NgBanana node){
+    _buffer.write(' [(${node.name})]="${node.value}"');
+  }
+
+  @override
   String toString() => _buffer.toString();
 }

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -123,29 +123,18 @@ void main() {
       );
     });
 
-    test('should parse a banana into a property and an event', () {
+    test('should parse a banana', () {
       expect(parse('<my-select [(input)]="textValue"></my-select>'), [
         new NgElement.unknown('my-select', childNodes: [
-          new NgProperty('input', 'textValue'),
-          new NgEvent('inputChange', 'textValue = \$event'),
+          new NgBanana('input', 'textValue'),
         ]),
       ]);
     });
 
     test('should parse a structural directive', () {
       expect(parse('<div *ngIf="foo"></div>'), [
-        new NgElement.unknown('template', childNodes: [
-          new NgProperty('ngIf', 'foo'),
-          new NgElement.unknown('div')
-        ])
-      ]);
-    });
-
-    test('should only produce one structural directive per element', () {
-      expect(parse('<div *ngIf="baz" *ngFor="let foo of bars"></div>'), [
-        new NgElement.unknown('template', childNodes: [
-          new NgProperty('ngIf', 'baz'),
-          new NgElement.unknown('div')
+        new NgElement.unknown('div', childNodes: [
+          new NgStructure('ngIf', 'foo'),
         ])
       ]);
     });

--- a/test/visitor/unparser_test.dart
+++ b/test/visitor/unparser_test.dart
@@ -9,7 +9,7 @@ void main() {
   NgAstNode parse(String text) =>
       const NgTemplateParser().parse(text, onError: (_) => null).first;
 
-  test('produces a desugared template', () {
+  test('produces a template', () {
     var ast = parse('<panel><div *ngIf="isTrue">Foo Bar</div><button '
         'class="fancy" disabled>Hello</button></panel>');
     var printer = new Unparser();
@@ -17,11 +17,9 @@ void main() {
     expect(
         printer.toString(),
         equals('<panel>\n'
-            '  <template [ngIf]="isTrue">\n'
-            '    <div>\n'
-            '      Foo Bar\n'
-            '    </div>\n'
-            '  </template>\n'
+            '  <div *ngIf="isTrue">\n'
+            '    Foo Bar\n'
+            '  </div>\n'
             '  <button class="fancy" disabled>\n'
             '    Hello\n'
             '  </button>\n'


### PR DESCRIPTION
Removed parsing of Dart expressions and de-sugaring of banana in a box and structural directives during the first pass.  This simplifies the initial parse, and allows unparsing/migrating to be a bit easier.

In order to correctly de-sugar structural directives, we need to directive class itself.  It follows that this process should be made a part of resolution and not parsing.