### PR TITLE
Groundwork for more elementary tokens. 

### DIFF
--- a/lib/src/simple_token.dart
+++ b/lib/src/simple_token.dart
@@ -1,0 +1,116 @@
+library angular_ast.src.simple_token;
+
+import 'package:quiver/core.dart';
+
+part 'token/simple_type.dart';
+
+class NgSimpleToken {
+  //Probably don't need
+  factory NgSimpleToken.closeBrace(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.closeBrace, offset);
+  }
+
+  factory NgSimpleToken.closeBracket(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.closeBracket, offset);
+  }
+
+  factory NgSimpleToken.closeParen(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.closeParen, offset);
+  }
+
+  factory NgSimpleToken.commentBegin(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.commentBegin, offset);
+  }
+
+  factory NgSimpleToken.commentEnd(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.commentEnd, offset);
+  }
+
+  factory NgSimpleToken.doubleQuote(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.doubleQuote, offset);
+  }
+
+  factory NgSimpleToken.elementStart(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.elementStart, offset);
+  }
+
+  factory NgSimpleToken.elementEnd(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.elementEnd, offset);
+  }
+
+  factory NgSimpleToken.elementEndVoid(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.elementEndVoid, offset);
+  }
+
+  factory NgSimpleToken.EOF(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.EOF, offset);
+  }
+
+  factory NgSimpleToken.equalSign(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.equalSign, offset);
+  }
+
+  factory NgSimpleToken.forwardSlash(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.forwardSlash, offset);
+  }
+
+  factory NgSimpleToken.hash(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.hash, offset);
+  }
+
+  //Probably don't need
+  factory NgSimpleToken.openBrace(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.openBrace, offset);
+  }
+
+  factory NgSimpleToken.openBracket(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.openBracket, offset);
+  }
+
+  factory NgSimpleToken.openParen(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.openParen, offset);
+  }
+
+  factory NgSimpleToken.singleQuote(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.singleQuote, offset);
+  }
+
+  factory NgSimpleToken.text(int offset, String lexeme) {
+    return new NgSimpleToken(new NgSimpleTokenType.textType(lexeme), offset);
+  }
+
+  factory NgSimpleToken.unexpectedChar(int offset, String lexeme) {
+    return new NgSimpleToken(
+        new NgSimpleTokenType.unexpectedChar(lexeme), offset);
+  }
+
+  factory NgSimpleToken.whitespace(int offset, String lexeme) {
+    return new NgSimpleToken(
+        new NgSimpleTokenType.whitespaceType(lexeme), offset);
+  }
+
+  const NgSimpleToken._(this.type, this.offset);
+
+  NgSimpleToken(this.type, this.offset);
+
+  @override
+  bool operator ==(Object o) {
+    if (o is NgSimpleToken) {
+      return o.offset == offset && o.type == type;
+    }
+    return false;
+  }
+
+  @override
+  int get hashCode => hash2(offset, type);
+
+  int get end => offset + length;
+  int get length => lexeme.length;
+  String get lexeme => type.lexeme;
+
+  final int offset;
+  final NgSimpleTokenType type;
+
+  @override
+  String toString() => '#$NgSimpleToken(${type.name}) {$offset:$lexeme}';
+}

--- a/lib/src/simple_tokenizer.dart
+++ b/lib/src/simple_tokenizer.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:angular_ast/src/simple_token.dart';
+import 'package:charcode/charcode.dart';
+import 'package:string_scanner/string_scanner.dart';
+
+class NgSimpleTokenizer {}
+
+class NgSimpleScanner {
+  static final _quoteMatches = new RegExp(r'("([^"\\]|\\.)*")|'
+      r"('([^'\\]|\\.)*')|"
+      r'(^")|'
+      r"(^')");
+  static final _allTextMatches = new RegExp(r'(^[^\<]+)|(^<)');
+  static final _allElementMatches = new RegExp(r'(^\])|'
+      r'(^\!\-\-)|'
+      r'(^\-\-)|'
+      r'(^\))|'
+      r'(^")|'
+      r'(^>)|'
+      r'(^\/>)|'
+      r'(^")|'
+      r'(^\/)|'
+      r'(^\[)|'
+      r'(^\()|'
+      r'(^[\s]+)|'
+      r'(^[a-zA-Z0-9\-\_]+)');
+
+  final StringScanner _scanner;
+  _NgSimpleScannerState _state = _NgSimpleScannerState.text;
+
+  factory NgSimpleScanner(String html, {sourceUrl}) {
+    return new NgSimpleScanner._(new StringScanner(html, sourceUrl: sourceUrl));
+  }
+
+  NgSimpleScanner._(this._scanner);
+
+  NgSimpleToken scan() {
+    switch (_state) {
+      case _NgSimpleScannerState.element:
+        return scanElement();
+      case _NgSimpleScannerState.text:
+        return scanText();
+    }
+    return null;
+  }
+
+  NgSimpleToken scanElement() {}
+
+  NgSimpleToken scanText() {
+    int initialOffset = _scanner.position;
+    if (_scanner.peekChar() == null) {
+      return new NgSimpleToken.EOF(initialOffset);
+    }
+    if (_scanner.scan(_allTextMatches)) {
+      if (_scanner.lastMatch.group(1) != null) {
+        return new NgSimpleToken.text(
+            initialOffset, _scanner.substring(initialOffset));
+      }
+      if (_scanner.lastMatch.group(2) != null) {
+        _state = _NgSimpleScannerState.element;
+        return new NgSimpleToken.elementStart(initialOffset);
+      }
+    }
+    return new NgSimpleToken.unexpectedChar(
+        initialOffset, _scanner.readChar().toString());
+  }
+}
+
+enum _NgSimpleScannerState { text, element }

--- a/lib/src/token/simple_type.dart
+++ b/lib/src/token/simple_type.dart
@@ -1,0 +1,84 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+part of angular_ast.src.simple_token;
+
+class NgSimpleTokenType {
+  //probably not needed
+  static const closeBrace =
+      const NgSimpleTokenType._('closeBrace', lexeme: '}');
+
+  static const closeBracket =
+      const NgSimpleTokenType._('closeBracket', lexeme: ']');
+
+  static const closeParen =
+      const NgSimpleTokenType._('closeParen', lexeme: ')');
+
+  static const commentBegin =
+      const NgSimpleTokenType._('commentBegin', lexeme: '!--');
+
+  static const commentEnd =
+      const NgSimpleTokenType._('commendEnd', lexeme: '--');
+
+  static const doubleQuote =
+      const NgSimpleTokenType._('doubleQuote', lexeme: '"');
+
+  static const elementStart = const NgSimpleTokenType._(
+    'elementStart',
+    lexeme: '<',
+  );
+
+  static const elementEnd =
+      const NgSimpleTokenType._('elementEnd', lexeme: '>');
+
+  static const elementEndVoid =
+      const NgSimpleTokenType._('elementEndVoid', lexeme: '/>');
+
+  static const equalSign = const NgSimpleTokenType._('equalSign', lexeme: '=');
+
+  static const EOF = const NgSimpleTokenType._('EOF', lexeme: '');
+
+  static const forwardSlash =
+      const NgSimpleTokenType._('forwardSlash', lexeme: '/');
+
+  static const hash = const NgSimpleTokenType._('hash', lexeme: '#');
+
+  //Probably not needed
+  static const openBrace = const NgSimpleTokenType._('openBrace', lexeme: '{');
+
+  static const openBracket =
+      const NgSimpleTokenType._('openBracket', lexeme: '[');
+
+  static const openParen = const NgSimpleTokenType._('openParen', lexeme: '(');
+
+  static const singleQuote =
+      const NgSimpleTokenType._('singleQuote', lexeme: "'");
+
+  NgSimpleTokenType.textType(this.lexeme) : this.name = 'text';
+
+  NgSimpleTokenType.unexpectedChar(this.lexeme) : this.name = 'unexpectedChar';
+
+  NgSimpleTokenType.whitespaceType(this.lexeme) : this.name = 'whitespace';
+
+  const NgSimpleTokenType._(this.name, {this.lexeme});
+
+  NgSimpleTokenType(this.name, this.lexeme);
+
+  final String name;
+  final String lexeme;
+
+  @override
+  String toString() => '#$NgSimpleTokenType {$name}';
+
+  @override
+  bool operator ==(Object o) {
+    if (o is NgSimpleTokenType) {
+      return o.name == name && o.lexeme == lexeme;
+    }
+    return false;
+  }
+
+  @override
+  int get hashCode => hash2(name, lexeme);
+}

--- a/test/simple_tokenizer_test.dart
+++ b/test/simple_tokenizer_test.dart
@@ -1,0 +1,21 @@
+import 'package:angular_ast/src/simple_tokenizer.dart';
+import 'package:angular_ast/src/simple_token.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('should greedily parse only text nodes', () {
+    expect(
+      new NgSimpleScanner("some random text <div>").scan(),
+      new NgSimpleToken.text(0, "some random text"),
+    );
+  });
+
+  test('should parse only an elementStart tag', () {
+    expect(new NgSimpleScanner("<div></div>").scan(),
+        new NgSimpleToken.elementStart(0));
+  });
+
+  test('should parse end of file', () {
+    expect(new NgSimpleScanner("").scan(), new NgSimpleToken.EOF(0));
+  });
+}


### PR DESCRIPTION
Refer to mfairhurt's "simpler lexer proposal". 

This PR will not impact the existing functionality. The plan is to create an error-recovery parser in parallel. Goal is to have two different parsers - a "fail-fast" and one with error-recovery. The end ast product should still not be changed by much.

Test cases for NgSimpleTokenizer will be added momentarily.