### PR TITLE
Simpler tokenizer

### DIFF
--- a/lib/src/simple_token.dart
+++ b/lib/src/simple_token.dart
@@ -5,6 +5,10 @@ import 'package:quiver/core.dart';
 part 'token/simple_type.dart';
 
 class NgSimpleToken {
+  factory NgSimpleToken.bang(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.bang, offset);
+  }
+
   //Probably don't need
   factory NgSimpleToken.closeBrace(int offset) {
     return new NgSimpleToken._(NgSimpleTokenType.closeBrace, offset);
@@ -18,16 +22,17 @@ class NgSimpleToken {
     return new NgSimpleToken._(NgSimpleTokenType.closeParen, offset);
   }
 
-  factory NgSimpleToken.commentBegin(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.commentBegin, offset);
-  }
-
-  factory NgSimpleToken.commentEnd(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.commentEnd, offset);
+  factory NgSimpleToken.dash(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.dash, offset);
   }
 
   factory NgSimpleToken.doubleQuote(int offset) {
     return new NgSimpleToken._(NgSimpleTokenType.doubleQuote, offset);
+  }
+
+  factory NgSimpleToken.doubleQuotedText(int offset, String lexeme) {
+    return new NgSimpleToken(
+        new NgSimpleTokenType.doubleQuotedText(lexeme), offset);
   }
 
   factory NgSimpleToken.elementStart(int offset) {
@@ -36,10 +41,6 @@ class NgSimpleToken {
 
   factory NgSimpleToken.elementEnd(int offset) {
     return new NgSimpleToken._(NgSimpleTokenType.elementEnd, offset);
-  }
-
-  factory NgSimpleToken.elementEndVoid(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.elementEndVoid, offset);
   }
 
   factory NgSimpleToken.EOF(int offset) {
@@ -75,8 +76,13 @@ class NgSimpleToken {
     return new NgSimpleToken._(NgSimpleTokenType.singleQuote, offset);
   }
 
+  factory NgSimpleToken.singleQuotedText(int offset, String lexeme) {
+    return new NgSimpleToken(
+        new NgSimpleTokenType.singleQuotedText(lexeme), offset);
+  }
+
   factory NgSimpleToken.text(int offset, String lexeme) {
-    return new NgSimpleToken(new NgSimpleTokenType.textType(lexeme), offset);
+    return new NgSimpleToken(new NgSimpleTokenType.text(lexeme), offset);
   }
 
   factory NgSimpleToken.unexpectedChar(int offset, String lexeme) {
@@ -85,8 +91,7 @@ class NgSimpleToken {
   }
 
   factory NgSimpleToken.whitespace(int offset, String lexeme) {
-    return new NgSimpleToken(
-        new NgSimpleTokenType.whitespaceType(lexeme), offset);
+    return new NgSimpleToken(new NgSimpleTokenType.whitespace(lexeme), offset);
   }
 
   const NgSimpleToken._(this.type, this.offset);

--- a/lib/src/simple_token.dart
+++ b/lib/src/simple_token.dart
@@ -43,15 +43,6 @@ class NgSimpleToken {
         NgSimpleTokenType.dashedIdentifier, offset, lexeme);
   }
 
-  factory NgSimpleToken.doubleQuote(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.doubleQuote, offset, '"');
-  }
-
-  factory NgSimpleToken.doubleQuotedText(int offset, String lexeme) {
-    return new NgSimpleToken(
-        NgSimpleTokenType.doubleQuotedText, offset, lexeme);
-  }
-
   factory NgSimpleToken.tagStart(int offset) {
     return new NgSimpleToken._(NgSimpleTokenType.tagStart, offset, '<');
   }
@@ -97,15 +88,6 @@ class NgSimpleToken {
     return new NgSimpleToken._(NgSimpleTokenType.period, offset, '.');
   }
 
-  factory NgSimpleToken.singleQuote(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.singleQuote, offset, "'");
-  }
-
-  factory NgSimpleToken.singleQuotedText(int offset, String lexeme) {
-    return new NgSimpleToken(
-        NgSimpleTokenType.singleQuotedText, offset, lexeme);
-  }
-
   factory NgSimpleToken.star(int offset) {
     return new NgSimpleToken._(NgSimpleTokenType.star, offset, '*');
   }
@@ -145,4 +127,57 @@ class NgSimpleToken {
 
   @override
   String toString() => '#$NgSimpleToken(${type.name}) {$offset:$lexeme}';
+}
+
+class NgSimpleQuoteToken extends NgSimpleToken {
+  factory NgSimpleQuoteToken.doubleQuotedText(
+      int offset, String lexeme, bool isClosed) {
+    return new NgSimpleQuoteToken(
+        NgSimpleTokenType.doubleQuote, offset, lexeme, isClosed);
+  }
+
+  factory NgSimpleQuoteToken.singleQuotedText(
+      int offset, String lexeme, bool isClosed) {
+    return new NgSimpleQuoteToken(
+        NgSimpleTokenType.singleQuote, offset, lexeme, isClosed);
+  }
+
+  final int
+      quoteOffset; //super.offset will be for text only; this is for Quote begin
+  final int quoteEndOffset; //If null, indicated unclosed
+  String _quotedLexeme;
+
+  NgSimpleQuoteToken(
+      NgSimpleTokenType type, this.quoteOffset, String lexeme, bool isClosed)
+      : quoteEndOffset = (isClosed ? quoteOffset + lexeme.length : null),
+        super(
+            type,
+            quoteOffset + 1,
+            lexeme.substring(
+                1, (isClosed ? lexeme.length - 1 : lexeme.length))) {
+    _quotedLexeme = lexeme;
+  }
+
+  @override
+  bool operator ==(Object o) {
+    if (o is NgSimpleQuoteToken) {
+      return o.offset == offset &&
+          o.type == type &&
+          o.quoteOffset == quoteOffset &&
+          o.quoteEndOffset == quoteEndOffset;
+    }
+    return false;
+  }
+
+  String get quotedLexeme => _quotedLexeme;
+  String get quote => (type == NgSimpleTokenType.doubleQuote) ? '"' : "'";
+  bool get isClosed => quoteEndOffset != null;
+  int get quotedLength => _quotedLexeme.length;
+
+  @override
+  int get hashCode => hash4(super.hashCode, lexeme, quoteOffset, end);
+
+  @override
+  String toString() =>
+      '#$NgSimpleQuoteToken(${type.name}) {$quoteOffset:$quotedLexeme}';
 }

--- a/lib/src/simple_token.dart
+++ b/lib/src/simple_token.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 library angular_ast.src.simple_token;
 
 import 'package:quiver/core.dart';

--- a/lib/src/simple_token.dart
+++ b/lib/src/simple_token.dart
@@ -22,6 +22,14 @@ class NgSimpleToken {
     return new NgSimpleToken._(NgSimpleTokenType.closeParen, offset);
   }
 
+  factory NgSimpleToken.commentBegin(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.commentBegin, offset);
+  }
+
+  factory NgSimpleToken.commentEnd(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.commentEnd, offset);
+  }
+
   factory NgSimpleToken.dash(int offset) {
     return new NgSimpleToken._(NgSimpleTokenType.dash, offset);
   }
@@ -35,12 +43,12 @@ class NgSimpleToken {
         new NgSimpleTokenType.doubleQuotedText(lexeme), offset);
   }
 
-  factory NgSimpleToken.elementStart(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.elementStart, offset);
+  factory NgSimpleToken.tagStart(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.tagStart, offset);
   }
 
-  factory NgSimpleToken.elementEnd(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.elementEnd, offset);
+  factory NgSimpleToken.tagEnd(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.tagEnd, offset);
   }
 
   factory NgSimpleToken.EOF(int offset) {

--- a/lib/src/simple_token.dart
+++ b/lib/src/simple_token.dart
@@ -89,6 +89,10 @@ class NgSimpleToken {
         new NgSimpleTokenType.singleQuotedText(lexeme), offset);
   }
 
+  factory NgSimpleToken.star(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.star, offset);
+  }
+
   factory NgSimpleToken.text(int offset, String lexeme) {
     return new NgSimpleToken(new NgSimpleTokenType.text(lexeme), offset);
   }

--- a/lib/src/simple_token.dart
+++ b/lib/src/simple_token.dart
@@ -38,13 +38,18 @@ class NgSimpleToken {
     return new NgSimpleToken._(NgSimpleTokenType.dash, offset, '-');
   }
 
+  factory NgSimpleToken.dashedIdentifier(int offset, String lexeme) {
+    return new NgSimpleToken(
+        NgSimpleTokenType.dashedIdentifier, offset, lexeme);
+  }
+
   factory NgSimpleToken.doubleQuote(int offset) {
     return new NgSimpleToken._(NgSimpleTokenType.doubleQuote, offset, '"');
   }
 
   factory NgSimpleToken.doubleQuotedText(int offset, String lexeme) {
     return new NgSimpleToken(
-        new NgSimpleTokenType.doubleQuotedText(), offset, lexeme);
+        NgSimpleTokenType.doubleQuotedText, offset, lexeme);
   }
 
   factory NgSimpleToken.tagStart(int offset) {
@@ -71,6 +76,10 @@ class NgSimpleToken {
     return new NgSimpleToken._(NgSimpleTokenType.hash, offset, '#');
   }
 
+  factory NgSimpleToken.identifier(int offset, String lexeme) {
+    return new NgSimpleToken(NgSimpleTokenType.identifier, offset, lexeme);
+  }
+
   //Probably don't need
   factory NgSimpleToken.openBrace(int offset) {
     return new NgSimpleToken._(NgSimpleTokenType.openBrace, offset, '{');
@@ -84,13 +93,17 @@ class NgSimpleToken {
     return new NgSimpleToken._(NgSimpleTokenType.openParen, offset, '(');
   }
 
+  factory NgSimpleToken.period(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.period, offset, '.');
+  }
+
   factory NgSimpleToken.singleQuote(int offset) {
     return new NgSimpleToken._(NgSimpleTokenType.singleQuote, offset, "'");
   }
 
   factory NgSimpleToken.singleQuotedText(int offset, String lexeme) {
     return new NgSimpleToken(
-        new NgSimpleTokenType.singleQuotedText(), offset, lexeme);
+        NgSimpleTokenType.singleQuotedText, offset, lexeme);
   }
 
   factory NgSimpleToken.star(int offset) {
@@ -98,17 +111,15 @@ class NgSimpleToken {
   }
 
   factory NgSimpleToken.text(int offset, String lexeme) {
-    return new NgSimpleToken(new NgSimpleTokenType.text(), offset, lexeme);
+    return new NgSimpleToken(NgSimpleTokenType.text, offset, lexeme);
   }
 
   factory NgSimpleToken.unexpectedChar(int offset, String lexeme) {
-    return new NgSimpleToken(
-        new NgSimpleTokenType.unexpectedChar(), offset, lexeme);
+    return new NgSimpleToken(NgSimpleTokenType.unexpectedChar, offset, lexeme);
   }
 
   factory NgSimpleToken.whitespace(int offset, String lexeme) {
-    return new NgSimpleToken(
-        new NgSimpleTokenType.whitespace(), offset, lexeme);
+    return new NgSimpleToken(NgSimpleTokenType.whitespace, offset, lexeme);
   }
 
   const NgSimpleToken._(this.type, this.offset, this.lexeme);

--- a/lib/src/simple_token.dart
+++ b/lib/src/simple_token.dart
@@ -1,0 +1,116 @@
+library angular_ast.src.simple_token;
+
+import 'package:quiver/core.dart';
+
+part 'token/simple_type.dart';
+
+class NgSimpleToken {
+  //Probably don't need
+  factory NgSimpleToken.closeBrace(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.closeBrace, offset);
+  }
+
+  factory NgSimpleToken.closeBracket(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.closeBracket, offset);
+  }
+
+  factory NgSimpleToken.closeParen(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.closeParen, offset);
+  }
+
+  factory NgSimpleToken.commentBegin(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.commentBegin, offset);
+  }
+
+  factory NgSimpleToken.commentEnd(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.commentEnd, offset);
+  }
+
+  factory NgSimpleToken.doubleQuote(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.doubleQuote, offset);
+  }
+
+  factory NgSimpleToken.elementStart(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.elementStart, offset);
+  }
+
+  factory NgSimpleToken.elementEnd(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.elementEnd, offset);
+  }
+
+  factory NgSimpleToken.elementEndVoid(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.elementEndVoid, offset);
+  }
+
+  factory NgSimpleToken.EOF(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.EOF, offset);
+  }
+
+  factory NgSimpleToken.equalSign(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.equalSign, offset);
+  }
+
+  factory NgSimpleToken.forwardSlash(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.forwardSlash, offset);
+  }
+
+  factory NgSimpleToken.hash(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.hash, offset);
+  }
+
+  //Probably don't need
+  factory NgSimpleToken.openBrace(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.openBrace, offset);
+  }
+
+  factory NgSimpleToken.openBracket(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.openBracket, offset);
+  }
+
+  factory NgSimpleToken.openParen(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.openParen, offset);
+  }
+
+  factory NgSimpleToken.singleQuote(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.singleQuote, offset);
+  }
+
+  factory NgSimpleToken.text(int offset, String lexeme) {
+    return new NgSimpleToken(new NgSimpleTokenType.textType(lexeme), offset);
+  }
+
+  factory NgSimpleToken.unexpectedChar(int offset, String lexeme) {
+    return new NgSimpleToken(
+        new NgSimpleTokenType.unexpectedChar(lexeme), offset);
+  }
+
+  factory NgSimpleToken.whitespace(int offset, String lexeme) {
+    return new NgSimpleToken(
+        new NgSimpleTokenType.whitespaceType(lexeme), offset);
+  }
+
+  const NgSimpleToken._(this.type, this.offset);
+
+  NgSimpleToken(this.type, this.offset);
+
+  @override
+  bool operator ==(Object o) {
+    if (o is NgSimpleToken) {
+      return o.offset == offset && o.type == type;
+    }
+    return false;
+  }
+
+  @override
+  int get hashCode => hash2(offset, type);
+
+  int get end => offset + length;
+  int get length => lexeme.length;
+  String get lexeme => type.lexeme;
+
+  final int offset;
+  final NgSimpleTokenType type;
+
+  @override
+  String toString() => '#$NgSimpleToken(${type.name}) {$offset:$lexeme}';
+}

--- a/lib/src/simple_token.dart
+++ b/lib/src/simple_token.dart
@@ -10,109 +10,110 @@ part 'token/simple_type.dart';
 
 class NgSimpleToken {
   factory NgSimpleToken.bang(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.bang, offset);
+    return new NgSimpleToken._(NgSimpleTokenType.bang, offset, '!');
   }
 
   //Probably don't need
   factory NgSimpleToken.closeBrace(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.closeBrace, offset);
+    return new NgSimpleToken._(NgSimpleTokenType.closeBrace, offset, '}');
   }
 
   factory NgSimpleToken.closeBracket(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.closeBracket, offset);
+    return new NgSimpleToken._(NgSimpleTokenType.closeBracket, offset, ']');
   }
 
   factory NgSimpleToken.closeParen(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.closeParen, offset);
+    return new NgSimpleToken._(NgSimpleTokenType.closeParen, offset, ')');
   }
 
   factory NgSimpleToken.commentBegin(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.commentBegin, offset);
+    return new NgSimpleToken._(NgSimpleTokenType.commentBegin, offset, '<!--');
   }
 
   factory NgSimpleToken.commentEnd(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.commentEnd, offset);
+    return new NgSimpleToken._(NgSimpleTokenType.commentEnd, offset, '-->');
   }
 
   factory NgSimpleToken.dash(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.dash, offset);
+    return new NgSimpleToken._(NgSimpleTokenType.dash, offset, '-');
   }
 
   factory NgSimpleToken.doubleQuote(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.doubleQuote, offset);
+    return new NgSimpleToken._(NgSimpleTokenType.doubleQuote, offset, '"');
   }
 
   factory NgSimpleToken.doubleQuotedText(int offset, String lexeme) {
     return new NgSimpleToken(
-        new NgSimpleTokenType.doubleQuotedText(lexeme), offset);
+        new NgSimpleTokenType.doubleQuotedText(), offset, lexeme);
   }
 
   factory NgSimpleToken.tagStart(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.tagStart, offset);
+    return new NgSimpleToken._(NgSimpleTokenType.tagStart, offset, '<');
   }
 
   factory NgSimpleToken.tagEnd(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.tagEnd, offset);
+    return new NgSimpleToken._(NgSimpleTokenType.tagEnd, offset, '>');
   }
 
   factory NgSimpleToken.EOF(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.EOF, offset);
+    return new NgSimpleToken._(NgSimpleTokenType.EOF, offset, '');
   }
 
   factory NgSimpleToken.equalSign(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.equalSign, offset);
+    return new NgSimpleToken._(NgSimpleTokenType.equalSign, offset, '=');
   }
 
   factory NgSimpleToken.forwardSlash(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.forwardSlash, offset);
+    return new NgSimpleToken._(NgSimpleTokenType.forwardSlash, offset, '/');
   }
 
   factory NgSimpleToken.hash(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.hash, offset);
+    return new NgSimpleToken._(NgSimpleTokenType.hash, offset, '#');
   }
 
   //Probably don't need
   factory NgSimpleToken.openBrace(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.openBrace, offset);
+    return new NgSimpleToken._(NgSimpleTokenType.openBrace, offset, '{');
   }
 
   factory NgSimpleToken.openBracket(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.openBracket, offset);
+    return new NgSimpleToken._(NgSimpleTokenType.openBracket, offset, '[');
   }
 
   factory NgSimpleToken.openParen(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.openParen, offset);
+    return new NgSimpleToken._(NgSimpleTokenType.openParen, offset, '(');
   }
 
   factory NgSimpleToken.singleQuote(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.singleQuote, offset);
+    return new NgSimpleToken._(NgSimpleTokenType.singleQuote, offset, "'");
   }
 
   factory NgSimpleToken.singleQuotedText(int offset, String lexeme) {
     return new NgSimpleToken(
-        new NgSimpleTokenType.singleQuotedText(lexeme), offset);
+        new NgSimpleTokenType.singleQuotedText(), offset, lexeme);
   }
 
   factory NgSimpleToken.star(int offset) {
-    return new NgSimpleToken._(NgSimpleTokenType.star, offset);
+    return new NgSimpleToken._(NgSimpleTokenType.star, offset, '*');
   }
 
   factory NgSimpleToken.text(int offset, String lexeme) {
-    return new NgSimpleToken(new NgSimpleTokenType.text(lexeme), offset);
+    return new NgSimpleToken(new NgSimpleTokenType.text(), offset, lexeme);
   }
 
   factory NgSimpleToken.unexpectedChar(int offset, String lexeme) {
     return new NgSimpleToken(
-        new NgSimpleTokenType.unexpectedChar(lexeme), offset);
+        new NgSimpleTokenType.unexpectedChar(), offset, lexeme);
   }
 
   factory NgSimpleToken.whitespace(int offset, String lexeme) {
-    return new NgSimpleToken(new NgSimpleTokenType.whitespace(lexeme), offset);
+    return new NgSimpleToken(
+        new NgSimpleTokenType.whitespace(), offset, lexeme);
   }
 
-  const NgSimpleToken._(this.type, this.offset);
+  const NgSimpleToken._(this.type, this.offset, this.lexeme);
 
-  NgSimpleToken(this.type, this.offset);
+  NgSimpleToken(this.type, this.offset, this.lexeme);
 
   @override
   bool operator ==(Object o) {
@@ -124,13 +125,12 @@ class NgSimpleToken {
 
   @override
   int get hashCode => hash2(offset, type);
-
   int get end => offset + length;
   int get length => lexeme.length;
-  String get lexeme => type.lexeme;
 
   final int offset;
   final NgSimpleTokenType type;
+  final String lexeme;
 
   @override
   String toString() => '#$NgSimpleToken(${type.name}) {$offset:$lexeme}';

--- a/lib/src/simple_tokenizer.dart
+++ b/lib/src/simple_tokenizer.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/lib/src/simple_tokenizer.dart
+++ b/lib/src/simple_tokenizer.dart
@@ -28,8 +28,7 @@ class NgSimpleScanner {
   static bool matchesGroup(Match match, int group) =>
       match.group(group) != null;
 
-  static final _allTextMatches =
-      new RegExp(r'([^\<]+)|(<!--)|(<)');
+  static final _allTextMatches = new RegExp(r'([^\<]+)|(<!--)|(<)');
   static final _allElementMatches = new RegExp(r'(\])|' //1  ]
       r'(\!)|' //2  !
       r'(\-)|' //3  -

--- a/lib/src/simple_tokenizer.dart
+++ b/lib/src/simple_tokenizer.dart
@@ -5,7 +5,6 @@
 import 'package:angular_ast/src/simple_token.dart';
 import 'package:charcode/charcode.dart';
 import 'package:string_scanner/string_scanner.dart';
-import 'package:meta/meta.dart';
 
 class NgSimpleTokenizer {
   final NgSimpleScanner _scanner;
@@ -30,7 +29,7 @@ class NgSimpleScanner {
       match.group(group) != null;
 
   static final _allTextMatches =
-      new RegExp(r'([^\<]+)|(<!--)|(<)', multiLine: true);
+      new RegExp(r'([^\<]+)|(<!--)|(<)');
   static final _allElementMatches = new RegExp(r'(\])|' //1  ]
       r'(\!)|' //2  !
       r'(\-)|' //3  -
@@ -46,7 +45,8 @@ class NgSimpleScanner {
       r'(")|' //16 " (floating)
       r"(')|" //17 ' (floating)
       r"(<)|" //18 <
-      r"(=)"); //19 =
+      r"(=)|" //19 =
+      r"(\*)"); //20 *
   static final _commentEnd = new RegExp('-->');
 
   final StringScanner _scanner;
@@ -87,7 +87,8 @@ class NgSimpleScanner {
       _scanner.position++;
       if (_scanner.isDone) {
         _state = _NgSimpleScannerState.text;
-        return new NgSimpleToken.EOF(offset);
+        String substring = _scanner.string.substring(offset);
+        return new NgSimpleToken.text(offset, substring);
       }
     }
     _state = _NgSimpleScannerState.commentEnd;
@@ -97,7 +98,6 @@ class NgSimpleScanner {
   NgSimpleToken scanCommentEnd() {
     int offset = _scanner.position;
     _scanner.scan(_commentEnd);
-    Match match = _scanner.lastMatch;
     _state = _NgSimpleScannerState.text;
     return new NgSimpleToken.commentEnd(offset);
   }
@@ -162,6 +162,9 @@ class NgSimpleScanner {
       }
       if (matchesGroup(match, 19)) {
         return new NgSimpleToken.equalSign(offset);
+      }
+      if (matchesGroup(match, 20)) {
+        return new NgSimpleToken.star(offset);
       }
     }
     return new NgSimpleToken.unexpectedChar(

--- a/lib/src/simple_tokenizer.dart
+++ b/lib/src/simple_tokenizer.dart
@@ -37,7 +37,7 @@ class NgSimpleScanner {
       r'(\[)|' //7  [
       r'(\()|' //8  (
       r'([\s]+)|' //9 whitespace
-      r'([a-zA-Z0-9]([a-zA-Z0-9\-\_]*[a-zA-Z0-9])?)|' //10 any alphanumeric + '-' + '_'
+      r'([a-zA-Z]([\w\_\-])*[a-zA-Z0-9]?)|' //10 any alphanumeric + '-' + '_'
       r'("([^"\\]|\\.)*")|' //12 closed double quote (includes group 13)
       r"('([^'\\]|\\.)*')|" //14 closed single quote (includes group 15)
       r'(")|' //16 " (floating)
@@ -45,7 +45,8 @@ class NgSimpleScanner {
       r"(<)|" //18 <
       r"(=)|" //19 =
       r"(\*)|" //20 *
-      r"(\#)"); //21 #
+      r"(\#)|" //21 #
+      r"(\.)"); //22 .
   static final _commentEnd = new RegExp('-->');
 
   final StringScanner _scanner;
@@ -137,10 +138,11 @@ class NgSimpleScanner {
         return new NgSimpleToken.whitespace(offset, _scanner.substring(offset));
       }
       if (matchesGroup(match, 10)) {
-        return new NgSimpleToken.text(offset, _scanner.substring(offset));
-      }
-      if (matchesGroup(match, 11)) {
-        return new NgSimpleToken.text(offset, _scanner.substring(offset));
+        String s = _scanner.substring(offset);
+        if (s.contains("-")) {
+          return new NgSimpleToken.dashedIdentifier(offset, s);
+        }
+        return new NgSimpleToken.identifier(offset, s);
       }
       if (matchesGroup(match, 12)) {
         return new NgSimpleToken.doubleQuotedText(
@@ -167,6 +169,9 @@ class NgSimpleScanner {
       }
       if (matchesGroup(match, 21)) {
         return new NgSimpleToken.hash(offset);
+      }
+      if (matchesGroup(match, 22)) {
+        return new NgSimpleToken.period(offset);
       }
     }
     return new NgSimpleToken.unexpectedChar(

--- a/lib/src/simple_tokenizer.dart
+++ b/lib/src/simple_tokenizer.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:angular_ast/src/simple_token.dart';
+import 'package:charcode/charcode.dart';
+import 'package:string_scanner/string_scanner.dart';
+
+class NgSimpleTokenizer {}
+
+class NgSimpleScanner {
+  static final _quoteMatches = new RegExp(r'("([^"\\]|\\.)*")|'
+      r"('([^'\\]|\\.)*')|"
+      r'(^")|'
+      r"(^')");
+  static final _allTextMatches = new RegExp(r'(^[^\<]+)|(^<)');
+  static final _allElementMatches = new RegExp(r'(^\])|'
+      r'(^\!\-\-)|'
+      r'(^\-\-)|'
+      r'(^\))|'
+      r'(^")|'
+      r'(^>)|'
+      r'(^\/>)|'
+      r'(^")|'
+      r'(^\/)|'
+      r'(^\[)|'
+      r'(^\()|'
+      r'(^[\s]+)|'
+      r'(^[a-zA-Z0-9\-\_]+)');
+
+  final StringScanner _scanner;
+  _NgSimpleScannerState _state = _NgSimpleScannerState.text;
+
+  factory NgSimpleScanner(String html, {sourceUrl}) {
+    return new NgSimpleScanner._(new StringScanner(html, sourceUrl: sourceUrl));
+  }
+
+  NgSimpleScanner._(this._scanner);
+
+  NgSimpleToken scan() {
+    switch (_state) {
+      case _NgSimpleScannerState.element:
+        return scanElement();
+      case _NgSimpleScannerState.text:
+        return scanText();
+    }
+    return null;
+  }
+
+  NgSimpleToken scanElement() {}
+
+  NgSimpleToken scanText() {
+    int initialOffset = _scanner.position;
+    if (_scanner.peekChar() == null) {
+      return new NgSimpleToken.EOF(initialOffset);
+    }
+    if (_scanner.scan(_allTextMatches)) {
+      if (_scanner.lastMatch.group(1) != null) {
+        return new NgSimpleToken.text(
+            initialOffset, _scanner.substring(initialOffset));
+      }
+      if (_scanner.lastMatch.group(2) != null) {
+        _state = _NgSimpleScannerState.element;
+        return new NgSimpleToken.elementStart(initialOffset);
+      }
+    }
+    return new NgSimpleToken.unexpectedChar(
+        initialOffset, _scanner.readChar().toString());
+  }
+}
+
+enum _NgSimpleScannerState { text, element }

--- a/lib/src/simple_tokenizer.dart
+++ b/lib/src/simple_tokenizer.dart
@@ -38,15 +38,13 @@ class NgSimpleScanner {
       r'(\()|' //8  (
       r'([\s]+)|' //9 whitespace
       r'([a-zA-Z]([\w\_\-])*[a-zA-Z0-9]?)|' //10 any alphanumeric + '-' + '_'
-      r'("([^"\\]|\\.)*")|' //12 closed double quote (includes group 13)
-      r"('([^'\\]|\\.)*')|" //14 closed single quote (includes group 15)
-      r'(")|' //16 " (floating)
-      r"(')|" //17 ' (floating)
-      r"(<)|" //18 <
-      r"(=)|" //19 =
-      r"(\*)|" //20 *
-      r"(\#)|" //21 #
-      r"(\.)"); //22 .
+      r'("([^"\\]|\\.)*"?)|' //12 closed double quote (includes group 13)
+      r"('([^'\\]|\\.)*'?)|" //14 closed single quote (includes group 15)
+      r"(<)|" //16 <
+      r"(=)|" //17 =
+      r"(\*)|" //18 *
+      r"(\#)|" //19 #
+      r"(\.)"); //20 .
   static final _commentEnd = new RegExp('-->');
 
   final StringScanner _scanner;
@@ -145,32 +143,30 @@ class NgSimpleScanner {
         return new NgSimpleToken.identifier(offset, s);
       }
       if (matchesGroup(match, 12)) {
-        return new NgSimpleToken.doubleQuotedText(
-            offset, _scanner.substring(offset).replaceAll(r'\"', '"'));
+        String lexeme = _scanner.substring(offset).replaceAll(r'\"', '"');
+        bool isClosed = lexeme[lexeme.length - 1] == '"';
+        return new NgSimpleQuoteToken.doubleQuotedText(
+            offset, lexeme, isClosed);
       }
       if (matchesGroup(match, 14)) {
-        return new NgSimpleToken.singleQuotedText(
-            offset, _scanner.substring(offset).replaceAll(r"\'", "'"));
+        String lexeme = _scanner.substring(offset).replaceAll(r"\'", "'");
+        bool isClosed = lexeme[lexeme.length - 1] == "'";
+        return new NgSimpleQuoteToken.singleQuotedText(
+            offset, lexeme, isClosed);
       }
       if (matchesGroup(match, 16)) {
-        return new NgSimpleToken.doubleQuote(offset);
-      }
-      if (matchesGroup(match, 17)) {
-        return new NgSimpleToken.singleQuote(offset);
-      }
-      if (matchesGroup(match, 18)) {
         return new NgSimpleToken.tagStart(offset);
       }
-      if (matchesGroup(match, 19)) {
+      if (matchesGroup(match, 17)) {
         return new NgSimpleToken.equalSign(offset);
       }
-      if (matchesGroup(match, 20)) {
+      if (matchesGroup(match, 18)) {
         return new NgSimpleToken.star(offset);
       }
-      if (matchesGroup(match, 21)) {
+      if (matchesGroup(match, 19)) {
         return new NgSimpleToken.hash(offset);
       }
-      if (matchesGroup(match, 22)) {
+      if (matchesGroup(match, 20)) {
         return new NgSimpleToken.period(offset);
       }
     }

--- a/lib/src/simple_tokenizer.dart
+++ b/lib/src/simple_tokenizer.dart
@@ -5,17 +5,20 @@
 import 'package:angular_ast/src/simple_token.dart';
 import 'package:charcode/charcode.dart';
 import 'package:string_scanner/string_scanner.dart';
+import 'package:meta/meta.dart';
 
 class NgSimpleTokenizer {
-  final NgSimpleScanner _scanner;
+  @literal
+  const factory NgSimpleTokenizer() = NgSimpleTokenizer._;
 
-  NgSimpleTokenizer(String template) : _scanner = new NgSimpleScanner(template);
+  const NgSimpleTokenizer._();
 
-  Iterable<NgSimpleToken> tokenize() sync* {
-    NgSimpleToken token = _scanner.scan();
+  Iterable<NgSimpleToken> tokenize(String template) sync* {
+    final scanner = new NgSimpleScanner(template);
+    NgSimpleToken token = scanner.scan();
     while (token.type != NgSimpleTokenType.EOF) {
       yield token;
-      token = _scanner.scan();
+      token = scanner.scan();
     }
   }
 }

--- a/lib/src/simple_tokenizer.dart
+++ b/lib/src/simple_tokenizer.dart
@@ -29,7 +29,8 @@ class NgSimpleScanner {
   static bool matchesGroup(Match match, int group) =>
       match.group(group) != null;
 
-  static final _allTextMatches = new RegExp(r'([^\<]+)|(<!--)|(<)', multiLine: true);
+  static final _allTextMatches =
+      new RegExp(r'([^\<]+)|(<!--)|(<)', multiLine: true);
   static final _allElementMatches = new RegExp(r'(\])|' //1  ]
       r'(\!)|' //2  !
       r'(\-)|' //3  -
@@ -77,7 +78,7 @@ class NgSimpleScanner {
 
   NgSimpleToken scanComment() {
     int offset = _scanner.position;
-    while(true) {
+    while (true) {
       if (_scanner.peekChar() == $dash &&
           _scanner.peekChar(1) == $dash &&
           _scanner.peekChar(2) == $gt) {

--- a/lib/src/simple_tokenizer.dart
+++ b/lib/src/simple_tokenizer.dart
@@ -5,37 +5,57 @@
 import 'package:angular_ast/src/simple_token.dart';
 import 'package:charcode/charcode.dart';
 import 'package:string_scanner/string_scanner.dart';
+import 'package:meta/meta.dart';
 
-class NgSimpleTokenizer {}
+class NgSimpleTokenizer {
+  @literal
+  const factory NgSimpleTokenizer() = NgSimpleTokenizer._;
+
+  const NgSimpleTokenizer._();
+
+  Iterable<NgSimpleToken> tokenize(String template) sync* {
+    final scanner = new NgSimpleScanner(template);
+    NgSimpleToken token = scanner.scan();
+    while (token.type != NgSimpleTokenType.EOF) {
+      yield token;
+      token = scanner.scan();
+    }
+  }
+}
 
 class NgSimpleScanner {
-  static final _quoteMatches = new RegExp(r'("([^"\\]|\\.)*")|'
-      r"('([^'\\]|\\.)*')|"
-      r'(^")|'
-      r"(^')");
+  static bool matchesGroup(Match match, int group) =>
+      match.group(group) != null;
+
   static final _allTextMatches = new RegExp(r'(^[^\<]+)|(^<)');
-  static final _allElementMatches = new RegExp(r'(^\])|'
-      r'(^\!\-\-)|'
-      r'(^\-\-)|'
-      r'(^\))|'
-      r'(^")|'
-      r'(^>)|'
-      r'(^\/>)|'
-      r'(^")|'
-      r'(^\/)|'
-      r'(^\[)|'
-      r'(^\()|'
-      r'(^[\s]+)|'
-      r'(^[a-zA-Z0-9\-\_]+)');
+  static final _allElementMatches = new RegExp(r'(^\])|' //1  ]
+      r'(^\!)|' //2  !
+      r'(^\-)|' //3  -
+      r'(^\))|' //4  )
+      r'(^>)|' //5  >
+      r'(^\/)|' //6  /
+      r'(^\[)|' //7  [
+      r'(^\()|' //8  (
+      r'(^[\s]+)|' //9 whitespace
+      r'(^[a-zA-Z][\w\-\_]*[\w])|' //10 any alphanumeric + '-' + '_'
+      r'("([^"\\]|\\.)*")|' //11 closed double quote (includes group 12)
+      r"('([^'\\]|\\.)*')|" //13 closed single quote (includes group 14)
+      r'(^")|' //15 " (floating)
+      r"(^')|" //16 ' (floating)
+      r"(^<)"); //17 <
 
   final StringScanner _scanner;
   _NgSimpleScannerState _state = _NgSimpleScannerState.text;
 
-  factory NgSimpleScanner(String html, {sourceUrl}) {
-    return new NgSimpleScanner._(new StringScanner(html, sourceUrl: sourceUrl));
+  factory NgSimpleScanner(String html, {sourceUrl, initialTextState: true}) {
+    return new NgSimpleScanner._(new StringScanner(html, sourceUrl: sourceUrl),
+        initialTextState: initialTextState);
   }
 
-  NgSimpleScanner._(this._scanner);
+  NgSimpleScanner._(this._scanner, {initialTextState})
+      : _state = (initialTextState)
+            ? _NgSimpleScannerState.text
+            : _NgSimpleScannerState.element;
 
   NgSimpleToken scan() {
     switch (_state) {
@@ -47,25 +67,83 @@ class NgSimpleScanner {
     return null;
   }
 
-  NgSimpleToken scanElement() {}
-
-  NgSimpleToken scanText() {
-    int initialOffset = _scanner.position;
+  NgSimpleToken scanElement() {
+    int offset = _scanner.position;
     if (_scanner.peekChar() == null) {
-      return new NgSimpleToken.EOF(initialOffset);
+      return new NgSimpleToken.EOF(offset);
     }
-    if (_scanner.scan(_allTextMatches)) {
-      if (_scanner.lastMatch.group(1) != null) {
-        return new NgSimpleToken.text(
-            initialOffset, _scanner.substring(initialOffset));
+    if (_scanner.scan(_allElementMatches)) {
+      Match match = _scanner.lastMatch;
+      if (matchesGroup(match, 1)) {
+        return new NgSimpleToken.closeBracket(offset);
       }
-      if (_scanner.lastMatch.group(2) != null) {
-        _state = _NgSimpleScannerState.element;
-        return new NgSimpleToken.elementStart(initialOffset);
+      if (matchesGroup(match, 2)) {
+        return new NgSimpleToken.bang(offset);
+      }
+      if (matchesGroup(match, 3)) {
+        return new NgSimpleToken.dash(offset);
+      }
+      if (matchesGroup(match, 4)) {
+        return new NgSimpleToken.closeParen(offset);
+      }
+      if (matchesGroup(match, 5)) {
+        _state = _NgSimpleScannerState.text;
+        return new NgSimpleToken.elementEnd(offset);
+      }
+      if (matchesGroup(match, 6)) {
+        return new NgSimpleToken.forwardSlash(offset);
+      }
+      if (matchesGroup(match, 7)) {
+        return new NgSimpleToken.openBracket(offset);
+      }
+      if (matchesGroup(match, 8)) {
+        return new NgSimpleToken.openParen(offset);
+      }
+      if (matchesGroup(match, 9)) {
+        return new NgSimpleToken.whitespace(offset, _scanner.substring(offset));
+      }
+      if (matchesGroup(match, 10)) {
+        return new NgSimpleToken.text(offset, _scanner.substring(offset));
+      }
+      if (matchesGroup(match, 11)) {
+        return new NgSimpleToken.doubleQuotedText(
+            offset, _scanner.substring(offset));
+      }
+      if (matchesGroup(match, 13)) {
+        return new NgSimpleToken.singleQuotedText(
+            offset, _scanner.substring(offset));
+      }
+      if (matchesGroup(match, 15)) {
+        return new NgSimpleToken.doubleQuote(offset);
+      }
+      if (matchesGroup(match, 16)) {
+        return new NgSimpleToken.singleQuote(offset);
+      }
+      if (matchesGroup(match, 17)) {
+        return new NgSimpleToken.elementStart(offset);
       }
     }
     return new NgSimpleToken.unexpectedChar(
-        initialOffset, _scanner.readChar().toString());
+        offset, _scanner.readChar().toString());
+  }
+
+  NgSimpleToken scanText() {
+    int offset = _scanner.position;
+    if (_scanner.peekChar() == null) {
+      return new NgSimpleToken.EOF(offset);
+    }
+    if (_scanner.scan(_allTextMatches)) {
+      Match match = _scanner.lastMatch;
+      if (matchesGroup(match, 1)) {
+        return new NgSimpleToken.text(offset, _scanner.substring(offset));
+      }
+      if (matchesGroup(match, 2)) {
+        _state = _NgSimpleScannerState.element;
+        return new NgSimpleToken.elementStart(offset);
+      }
+    }
+    return new NgSimpleToken.unexpectedChar(
+        offset, _scanner.readChar().toString());
   }
 }
 

--- a/lib/src/simple_tokenizer.dart
+++ b/lib/src/simple_tokenizer.dart
@@ -24,10 +24,6 @@ class NgSimpleTokenizer {
 }
 
 class NgSimpleScanner {
-  String get state =>
-      _state == _NgSimpleScannerState.element ? "element" : "text";
-  String get remainingString => _scanner.rest;
-  String get elementRegex => _allElementMatches.toString();
   static bool matchesGroup(Match match, int group) =>
       match.group(group) != null;
 
@@ -48,7 +44,8 @@ class NgSimpleScanner {
       r"(')|" //17 ' (floating)
       r"(<)|" //18 <
       r"(=)|" //19 =
-      r"(\*)"); //20 *
+      r"(\*)|" //20 *
+      r"(\#)"); //21 #
   static final _commentEnd = new RegExp('-->');
 
   final StringScanner _scanner;
@@ -147,11 +144,11 @@ class NgSimpleScanner {
       }
       if (matchesGroup(match, 12)) {
         return new NgSimpleToken.doubleQuotedText(
-            offset, _scanner.substring(offset));
+            offset, _scanner.substring(offset).replaceAll(r'\"', '"'));
       }
       if (matchesGroup(match, 14)) {
         return new NgSimpleToken.singleQuotedText(
-            offset, _scanner.substring(offset));
+            offset, _scanner.substring(offset).replaceAll(r"\'", "'"));
       }
       if (matchesGroup(match, 16)) {
         return new NgSimpleToken.doubleQuote(offset);
@@ -167,6 +164,9 @@ class NgSimpleScanner {
       }
       if (matchesGroup(match, 20)) {
         return new NgSimpleToken.star(offset);
+      }
+      if (matchesGroup(match, 21)) {
+        return new NgSimpleToken.hash(offset);
       }
     }
     return new NgSimpleToken.unexpectedChar(

--- a/lib/src/token/simple_type.dart
+++ b/lib/src/token/simple_type.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/lib/src/token/simple_type.dart
+++ b/lib/src/token/simple_type.dart
@@ -55,8 +55,7 @@ class NgSimpleTokenType {
   static const singleQuote =
       const NgSimpleTokenType._('singleQuote', lexeme: "'");
 
-  static const star =
-      const NgSimpleTokenType._('star', lexeme: '*');
+  static const star = const NgSimpleTokenType._('star', lexeme: '*');
 
   NgSimpleTokenType.doubleQuotedText(this.lexeme)
       : this.name = 'doubleQuotedText';

--- a/lib/src/token/simple_type.dart
+++ b/lib/src/token/simple_type.dart
@@ -5,76 +5,63 @@
 part of angular_ast.src.simple_token;
 
 class NgSimpleTokenType {
-  static const bang = const NgSimpleTokenType._('bang', lexeme: '!');
+  static const bang = const NgSimpleTokenType._('bang');
 
   //probably not needed
-  static const closeBrace =
-      const NgSimpleTokenType._('closeBrace', lexeme: '}');
+  static const closeBrace = const NgSimpleTokenType._('closeBrace');
 
-  static const closeBracket =
-      const NgSimpleTokenType._('closeBracket', lexeme: ']');
+  static const closeBracket = const NgSimpleTokenType._('closeBracket');
 
-  static const closeParen =
-      const NgSimpleTokenType._('closeParen', lexeme: ')');
+  static const closeParen = const NgSimpleTokenType._('closeParen');
 
-  static const commentBegin =
-      const NgSimpleTokenType._('commentBegin', lexeme: '<!--');
+  static const commentBegin = const NgSimpleTokenType._('commentBegin');
 
-  static const commentEnd =
-      const NgSimpleTokenType._('commentEnd', lexeme: '-->');
+  static const commentEnd = const NgSimpleTokenType._('commentEnd');
 
-  static const dash = const NgSimpleTokenType._('dash', lexeme: '-');
+  static const dash = const NgSimpleTokenType._('dash');
 
-  static const doubleQuote =
-      const NgSimpleTokenType._('doubleQuote', lexeme: '"');
+  static const doubleQuote = const NgSimpleTokenType._('doubleQuote');
 
   static const tagStart = const NgSimpleTokenType._(
     'tagStart',
-    lexeme: '<',
   );
 
-  static const tagEnd = const NgSimpleTokenType._('tagEnd', lexeme: '>');
+  static const tagEnd = const NgSimpleTokenType._('tagEnd');
 
-  static const equalSign = const NgSimpleTokenType._('equalSign', lexeme: '=');
+  static const equalSign = const NgSimpleTokenType._('equalSign');
 
-  static const EOF = const NgSimpleTokenType._('EOF', lexeme: '');
+  static const EOF = const NgSimpleTokenType._('EOF');
 
-  static const forwardSlash =
-      const NgSimpleTokenType._('forwardSlash', lexeme: '/');
+  static const forwardSlash = const NgSimpleTokenType._('forwardSlash');
 
-  static const hash = const NgSimpleTokenType._('hash', lexeme: '#');
+  static const hash = const NgSimpleTokenType._('hash');
 
   //Probably not needed
-  static const openBrace = const NgSimpleTokenType._('openBrace', lexeme: '{');
+  static const openBrace = const NgSimpleTokenType._('openBrace');
 
-  static const openBracket =
-      const NgSimpleTokenType._('openBracket', lexeme: '[');
+  static const openBracket = const NgSimpleTokenType._('openBracket');
 
-  static const openParen = const NgSimpleTokenType._('openParen', lexeme: '(');
+  static const openParen = const NgSimpleTokenType._('openParen');
 
-  static const singleQuote =
-      const NgSimpleTokenType._('singleQuote', lexeme: "'");
+  static const singleQuote = const NgSimpleTokenType._('singleQuote');
 
-  static const star = const NgSimpleTokenType._('star', lexeme: '*');
+  static const star = const NgSimpleTokenType._('star');
 
-  NgSimpleTokenType.doubleQuotedText(this.lexeme)
-      : this.name = 'doubleQuotedText';
+  NgSimpleTokenType.doubleQuotedText() : this.name = 'doubleQuotedText';
 
-  NgSimpleTokenType.singleQuotedText(this.lexeme)
-      : this.name = 'singleQuotedText';
+  NgSimpleTokenType.singleQuotedText() : this.name = 'singleQuotedText';
 
-  NgSimpleTokenType.text(this.lexeme) : this.name = 'text';
+  NgSimpleTokenType.text() : this.name = 'text';
 
-  NgSimpleTokenType.unexpectedChar(this.lexeme) : this.name = 'unexpectedChar';
+  NgSimpleTokenType.unexpectedChar() : this.name = 'unexpectedChar';
 
-  NgSimpleTokenType.whitespace(this.lexeme) : this.name = 'whitespace';
+  NgSimpleTokenType.whitespace() : this.name = 'whitespace';
 
-  const NgSimpleTokenType._(this.name, {this.lexeme});
+  const NgSimpleTokenType._(this.name);
 
-  NgSimpleTokenType(this.name, this.lexeme);
+  NgSimpleTokenType(this.name);
 
   final String name;
-  final String lexeme;
 
   @override
   String toString() => '#$NgSimpleTokenType {$name}';
@@ -82,11 +69,11 @@ class NgSimpleTokenType {
   @override
   bool operator ==(Object o) {
     if (o is NgSimpleTokenType) {
-      return o.name == name && o.lexeme == lexeme;
+      return o.name == name;
     }
     return false;
   }
 
   @override
-  int get hashCode => hash2(name, lexeme);
+  int get hashCode => name.hashCode;
 }

--- a/lib/src/token/simple_type.dart
+++ b/lib/src/token/simple_type.dart
@@ -20,6 +20,8 @@ class NgSimpleTokenType {
 
   static const dash = const NgSimpleTokenType._('dash');
 
+  static const dashedIdentifier = const NgSimpleTokenType._('dashedIdentifier');
+
   static const doubleQuote = const NgSimpleTokenType._('doubleQuote');
 
   static const tagStart = const NgSimpleTokenType._(
@@ -36,6 +38,8 @@ class NgSimpleTokenType {
 
   static const hash = const NgSimpleTokenType._('hash');
 
+  static const identifier = const NgSimpleTokenType._('identifier');
+
   //Probably not needed
   static const openBrace = const NgSimpleTokenType._('openBrace');
 
@@ -43,19 +47,21 @@ class NgSimpleTokenType {
 
   static const openParen = const NgSimpleTokenType._('openParen');
 
+  static const period = const NgSimpleTokenType._('period');
+
   static const singleQuote = const NgSimpleTokenType._('singleQuote');
 
   static const star = const NgSimpleTokenType._('star');
 
-  NgSimpleTokenType.doubleQuotedText() : this.name = 'doubleQuotedText';
+  static const doubleQuotedText = const NgSimpleTokenType._('doubleQuotedText');
 
-  NgSimpleTokenType.singleQuotedText() : this.name = 'singleQuotedText';
+  static const singleQuotedText = const NgSimpleTokenType._('singleQuotedText');
 
-  NgSimpleTokenType.text() : this.name = 'text';
+  static const text = const NgSimpleTokenType._('text');
 
-  NgSimpleTokenType.unexpectedChar() : this.name = 'unexpectedChar';
+  static const unexpectedChar = const NgSimpleTokenType._('unexpectedChar');
 
-  NgSimpleTokenType.whitespace() : this.name = 'whitespace';
+  static const whitespace = const NgSimpleTokenType._('whitespace');
 
   const NgSimpleTokenType._(this.name);
 

--- a/lib/src/token/simple_type.dart
+++ b/lib/src/token/simple_type.dart
@@ -17,18 +17,23 @@ class NgSimpleTokenType {
   static const closeParen =
       const NgSimpleTokenType._('closeParen', lexeme: ')');
 
+  static const commentBegin =
+      const NgSimpleTokenType._('commentBegin', lexeme: '<!--');
+
+  static const commentEnd =
+      const NgSimpleTokenType._('commentEnd', lexeme: '-->');
+
   static const dash = const NgSimpleTokenType._('dash', lexeme: '-');
 
   static const doubleQuote =
       const NgSimpleTokenType._('doubleQuote', lexeme: '"');
 
-  static const elementStart = const NgSimpleTokenType._(
-    'elementStart',
+  static const tagStart = const NgSimpleTokenType._(
+    'tagStart',
     lexeme: '<',
   );
 
-  static const elementEnd =
-      const NgSimpleTokenType._('elementEnd', lexeme: '>');
+  static const tagEnd = const NgSimpleTokenType._('tagEnd', lexeme: '>');
 
   static const equalSign = const NgSimpleTokenType._('equalSign', lexeme: '=');
 

--- a/lib/src/token/simple_type.dart
+++ b/lib/src/token/simple_type.dart
@@ -1,0 +1,84 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+part of angular_ast.src.simple_token;
+
+class NgSimpleTokenType {
+  //probably not needed
+  static const closeBrace =
+      const NgSimpleTokenType._('closeBrace', lexeme: '}');
+
+  static const closeBracket =
+      const NgSimpleTokenType._('closeBracket', lexeme: ']');
+
+  static const closeParen =
+      const NgSimpleTokenType._('closeParen', lexeme: ')');
+
+  static const commentBegin =
+      const NgSimpleTokenType._('commentBegin', lexeme: '!--');
+
+  static const commentEnd =
+      const NgSimpleTokenType._('commendEnd', lexeme: '--');
+
+  static const doubleQuote =
+      const NgSimpleTokenType._('doubleQuote', lexeme: '"');
+
+  static const elementStart = const NgSimpleTokenType._(
+    'elementStart',
+    lexeme: '<',
+  );
+
+  static const elementEnd =
+      const NgSimpleTokenType._('elementEnd', lexeme: '>');
+
+  static const elementEndVoid =
+      const NgSimpleTokenType._('elementEndVoid', lexeme: '/>');
+
+  static const equalSign = const NgSimpleTokenType._('equalSign', lexeme: '=');
+
+  static const EOF = const NgSimpleTokenType._('EOF', lexeme: '');
+
+  static const forwardSlash =
+      const NgSimpleTokenType._('forwardSlash', lexeme: '/');
+
+  static const hash = const NgSimpleTokenType._('hash', lexeme: '#');
+
+  //Probably not needed
+  static const openBrace = const NgSimpleTokenType._('openBrace', lexeme: '{');
+
+  static const openBracket =
+      const NgSimpleTokenType._('openBracket', lexeme: '[');
+
+  static const openParen = const NgSimpleTokenType._('openParen', lexeme: '(');
+
+  static const singleQuote =
+      const NgSimpleTokenType._('singleQuote', lexeme: "'");
+
+  NgSimpleTokenType.textType(this.lexeme) : this.name = 'text';
+
+  NgSimpleTokenType.unexpectedChar(this.lexeme) : this.name = 'unexpectedChar';
+
+  NgSimpleTokenType.whitespaceType(this.lexeme) : this.name = 'whitespace';
+
+  const NgSimpleTokenType._(this.name, {this.lexeme});
+
+  NgSimpleTokenType(this.name, this.lexeme);
+
+  final String name;
+  final String lexeme;
+
+  @override
+  String toString() => '#$NgSimpleTokenType {$name}';
+
+  @override
+  bool operator ==(Object o) {
+    if (o is NgSimpleTokenType) {
+      return o.name == name && o.lexeme == lexeme;
+    }
+    return false;
+  }
+
+  @override
+  int get hashCode => hash2(name, lexeme);
+}

--- a/lib/src/token/simple_type.dart
+++ b/lib/src/token/simple_type.dart
@@ -55,6 +55,9 @@ class NgSimpleTokenType {
   static const singleQuote =
       const NgSimpleTokenType._('singleQuote', lexeme: "'");
 
+  static const star =
+      const NgSimpleTokenType._('star', lexeme: '*');
+
   NgSimpleTokenType.doubleQuotedText(this.lexeme)
       : this.name = 'doubleQuotedText';
 

--- a/lib/src/token/simple_type.dart
+++ b/lib/src/token/simple_type.dart
@@ -5,6 +5,8 @@
 part of angular_ast.src.simple_token;
 
 class NgSimpleTokenType {
+  static const bang = const NgSimpleTokenType._('bang', lexeme: '!');
+
   //probably not needed
   static const closeBrace =
       const NgSimpleTokenType._('closeBrace', lexeme: '}');
@@ -15,11 +17,7 @@ class NgSimpleTokenType {
   static const closeParen =
       const NgSimpleTokenType._('closeParen', lexeme: ')');
 
-  static const commentBegin =
-      const NgSimpleTokenType._('commentBegin', lexeme: '!--');
-
-  static const commentEnd =
-      const NgSimpleTokenType._('commendEnd', lexeme: '--');
+  static const dash = const NgSimpleTokenType._('dash', lexeme: '-');
 
   static const doubleQuote =
       const NgSimpleTokenType._('doubleQuote', lexeme: '"');
@@ -31,9 +29,6 @@ class NgSimpleTokenType {
 
   static const elementEnd =
       const NgSimpleTokenType._('elementEnd', lexeme: '>');
-
-  static const elementEndVoid =
-      const NgSimpleTokenType._('elementEndVoid', lexeme: '/>');
 
   static const equalSign = const NgSimpleTokenType._('equalSign', lexeme: '=');
 
@@ -55,11 +50,17 @@ class NgSimpleTokenType {
   static const singleQuote =
       const NgSimpleTokenType._('singleQuote', lexeme: "'");
 
-  NgSimpleTokenType.textType(this.lexeme) : this.name = 'text';
+  NgSimpleTokenType.doubleQuotedText(this.lexeme)
+      : this.name = 'doubleQuotedText';
+
+  NgSimpleTokenType.singleQuotedText(this.lexeme)
+      : this.name = 'singleQuotedText';
+
+  NgSimpleTokenType.text(this.lexeme) : this.name = 'text';
 
   NgSimpleTokenType.unexpectedChar(this.lexeme) : this.name = 'unexpectedChar';
 
-  NgSimpleTokenType.whitespaceType(this.lexeme) : this.name = 'whitespace';
+  NgSimpleTokenType.whitespace(this.lexeme) : this.name = 'whitespace';
 
   const NgSimpleTokenType._(this.name, {this.lexeme});
 

--- a/test/simple_scanner_test.dart
+++ b/test/simple_scanner_test.dart
@@ -71,13 +71,13 @@ void main() {
         new NgSimpleToken.whitespace(0, "  "));
   });
 
-  test('element: should tokenize text', () {
+  test('element: should tokenize identifier', () {
     expect(tokenizeTag("my-element_tag [a]='y'>"),
-        new NgSimpleToken.text(0, "my-element_tag"));
+        new NgSimpleToken.dashedIdentifier(0, "my-element_tag"));
   });
 
   test('element: should tokenize single letter text', () {
-    expect(tokenizeTag("a href='blah>"), new NgSimpleToken.text(0, 'a'));
+    expect(tokenizeTag("a href='blah>"), new NgSimpleToken.identifier(0, 'a'));
   });
 
   test('element: should tokenize doubleQuoted text', () {

--- a/test/simple_scanner_test.dart
+++ b/test/simple_scanner_test.dart
@@ -24,7 +24,8 @@ void main() {
   });
 
   test('text node: should tokenize commentStart', () {
-    expect(new NgSimpleScanner("<!--Hello World-->").scan(), new NgSimpleToken.commentBegin(0));
+    expect(new NgSimpleScanner("<!--Hello World-->").scan(),
+        new NgSimpleToken.commentBegin(0));
   });
 
   //Element node

--- a/test/simple_scanner_test.dart
+++ b/test/simple_scanner_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:angular_ast/src/simple_tokenizer.dart';
 import 'package:angular_ast/src/simple_token.dart';
 import 'package:test/test.dart';

--- a/test/simple_scanner_test.dart
+++ b/test/simple_scanner_test.dart
@@ -1,0 +1,103 @@
+import 'package:angular_ast/src/simple_tokenizer.dart';
+import 'package:angular_ast/src/simple_token.dart';
+import 'package:test/test.dart';
+
+void main() {
+  NgSimpleToken tokenize(String html) => new NgSimpleScanner(html).scan();
+  NgSimpleToken tokenizeTag(String html) =>
+      new NgSimpleScanner(html, initialTextState: false).scan();
+
+  //Text node
+  test('text node: should tokenize text', () {
+    expect(
+      tokenize("some random text <div></div>"),
+      new NgSimpleToken.text(0, "some random text "),
+    );
+  });
+
+  test('text node: should tokenize elementStart tag', () {
+    expect(tokenize("<div></div>"), new NgSimpleToken.tagStart(0));
+  });
+
+  test('text node: should tokenize EOF', () {
+    expect(new NgSimpleScanner("").scan(), new NgSimpleToken.EOF(0));
+  });
+
+  test('text node: should tokenize commentStart', () {
+    expect(new NgSimpleScanner("<!--Hello World-->").scan(), new NgSimpleToken.commentBegin(0));
+  });
+
+  //Element node
+  test('element: should tokenize end bracket', () {
+    expect(tokenizeTag("]='someAttrValue'"), new NgSimpleToken.closeBracket(0));
+  });
+
+  test('element: should tokenize single bang', () {
+    expect(tokenizeTag("!-- some comment tag -->"), new NgSimpleToken.bang(0));
+  });
+
+  test('element: should tokenize single dash', () {
+    expect(tokenizeTag("-- some comment tag -->"), new NgSimpleToken.dash(0));
+  });
+
+  test('element: should tokenize closeParen', () {
+    expect(tokenizeTag(")='someAttrValue'"), new NgSimpleToken.closeParen(0));
+  });
+
+  test('element: should tokenze elementEnd', () {
+    expect(tokenizeTag("> some text </div>"), new NgSimpleToken.tagEnd(0));
+  });
+
+  test('element: should tokenize forwardSlash', () {
+    expect(tokenizeTag("/><div></div>"), new NgSimpleToken.forwardSlash(0));
+  });
+
+  test('element: should tokenize openBracket', () {
+    expect(tokenizeTag("[someInput]='blah'"), new NgSimpleToken.openBracket(0));
+  });
+
+  test('element: should tokenize openParen', () {
+    expect(tokenizeTag("(someEvent)='do something;'"),
+        new NgSimpleToken.openParen(0));
+  });
+
+  test('element: should tokenize whiteSpace', () {
+    expect(tokenizeTag("  someAttr='blah'"),
+        new NgSimpleToken.whitespace(0, "  "));
+  });
+
+  test('element: should tokenize text', () {
+    expect(tokenizeTag("my-element_tag [a]='y'>"),
+        new NgSimpleToken.text(0, "my-element_tag"));
+  });
+
+  test('element: should tokenize single letter text', () {
+    expect(tokenizeTag("a href='blah>"), new NgSimpleToken.text(0, 'a'));
+  });
+
+  test('element: should tokenize doubleQuoted text', () {
+    expect(tokenizeTag('"doSomething1; doSomething2"'),
+        new NgSimpleToken.doubleQuotedText(0, '"doSomething1; doSomething2"'));
+  });
+
+  test('element: should tokenize singleQuoted text', () {
+    expect(tokenizeTag("'doSomething1; doSomething2'"),
+        new NgSimpleToken.singleQuotedText(0, "'doSomething1; doSomething2'"));
+  });
+
+  test('element: should tokenize unclosed doubleQuote', () {
+    expect(tokenizeTag('" blah blah'), new NgSimpleToken.doubleQuote(0));
+  });
+
+  test('element: should tokenize unclosed singleQuote', () {
+    expect(tokenizeTag("' blah blah"), new NgSimpleToken.singleQuote(0));
+  });
+
+  test('element: should tokenize elementStart tag', () {
+    expect(tokenizeTag("<div></div>"), new NgSimpleToken.tagStart(0));
+  });
+
+  test('element: should tokenize equalSign', () {
+    expect(tokenizeTag("='SomeValue'"), new NgSimpleToken.equalSign(0));
+  });
+}

--- a/test/simple_scanner_test.dart
+++ b/test/simple_scanner_test.dart
@@ -81,21 +81,27 @@ void main() {
   });
 
   test('element: should tokenize doubleQuoted text', () {
-    expect(tokenizeTag('"doSomething1; doSomething2"'),
-        new NgSimpleToken.doubleQuotedText(0, '"doSomething1; doSomething2"'));
+    expect(
+        tokenizeTag('"doSomething1; doSomething2"'),
+        new NgSimpleQuoteToken.doubleQuotedText(
+            0, '"doSomething1; doSomething2"', true));
   });
 
   test('element: should tokenize singleQuoted text', () {
-    expect(tokenizeTag("'doSomething1; doSomething2'"),
-        new NgSimpleToken.singleQuotedText(0, "'doSomething1; doSomething2'"));
+    expect(
+        tokenizeTag("'doSomething1; doSomething2'"),
+        new NgSimpleQuoteToken.singleQuotedText(
+            0, "'doSomething1; doSomething2'", true));
   });
 
   test('element: should tokenize unclosed doubleQuote', () {
-    expect(tokenizeTag('" blah blah'), new NgSimpleToken.doubleQuote(0));
+    expect(tokenizeTag('" blah blah'),
+        new NgSimpleQuoteToken.doubleQuotedText(0, '" blah blah', false));
   });
 
   test('element: should tokenize unclosed singleQuote', () {
-    expect(tokenizeTag("' blah blah"), new NgSimpleToken.singleQuote(0));
+    expect(tokenizeTag("' blah blah"),
+        new NgSimpleQuoteToken.singleQuotedText(0, "' blah blah", false));
   });
 
   test('element: should tokenize elementStart tag', () {

--- a/test/simple_token_test.dart
+++ b/test/simple_token_test.dart
@@ -1,0 +1,241 @@
+import 'package:angular_ast/src/simple_token.dart';
+import 'package:test/test.dart';
+
+void main() {
+  NgSimpleToken token;
+
+  test('bang', () {
+    token = new NgSimpleToken.bang(0);
+    expect(token.lexeme, '!');
+    expect(token.end, 1);
+    expect(token.length, 1);
+    expect(token.offset, 0);
+    expect(token.type, NgSimpleTokenType.bang);
+  });
+
+  test('closeBracket', () {
+    token = new NgSimpleToken.closeBracket(0);
+    expect(token.lexeme, ']');
+    expect(token.end, 1);
+    expect(token.length, 1);
+    expect(token.offset, 0);
+    expect(token.type, NgSimpleTokenType.closeBracket);
+  });
+
+  test('closeParen', () {
+    token = new NgSimpleToken.closeParen(0);
+    expect(token.lexeme, ')');
+    expect(token.end, 1);
+    expect(token.length, 1);
+    expect(token.offset, 0);
+    expect(token.type, NgSimpleTokenType.closeParen);
+  });
+
+  test('commentBegin', () {
+    token = new NgSimpleToken.commentBegin(0);
+    expect(token.lexeme, '<!--');
+    expect(token.end, 4);
+    expect(token.length, 4);
+    expect(token.offset, 0);
+    expect(token.type, NgSimpleTokenType.commentBegin);
+  });
+
+  test('commentEnd', () {
+    token = new NgSimpleToken.commentEnd(0);
+    expect(token.lexeme, '-->');
+    expect(token.end, 3);
+    expect(token.length, 3);
+    expect(token.offset, 0);
+    expect(token.type, NgSimpleTokenType.commentEnd);
+  });
+
+  test('dash', () {
+    token = new NgSimpleToken.dash(0);
+    expect(token.lexeme, '-');
+    expect(token.end, 1);
+    expect(token.length, 1);
+    expect(token.offset, 0);
+    expect(token.type, NgSimpleTokenType.dash);
+  });
+
+  test('dashedIdenifier', () {
+    token = new NgSimpleToken.dashedIdentifier(0, 'some_dashed-identifier');
+    expect(token.lexeme, 'some_dashed-identifier');
+    expect(token.end, 22);
+    expect(token.length, 22);
+    expect(token.offset, 0);
+    expect(token.type, NgSimpleTokenType.dashedIdentifier);
+  });
+
+  test('tagStart', () {
+    token = new NgSimpleToken.tagStart(0);
+    expect(token.lexeme, '<');
+    expect(token.end, 1);
+    expect(token.length, 1);
+    expect(token.offset, 0);
+    expect(token.type, NgSimpleTokenType.tagStart);
+  });
+
+  test('tagEnd', () {
+    token = new NgSimpleToken.tagEnd(0);
+    expect(token.lexeme, '>');
+    expect(token.end, 1);
+    expect(token.length, 1);
+    expect(token.offset, 0);
+    expect(token.type, NgSimpleTokenType.tagEnd);
+  });
+
+  test('equalSign', () {
+    token = new NgSimpleToken.equalSign(0);
+    expect(token.lexeme, '=');
+    expect(token.end, 1);
+    expect(token.length, 1);
+    expect(token.offset, 0);
+    expect(token.type, NgSimpleTokenType.equalSign);
+  });
+
+  test('forwardSlash', () {
+    token = new NgSimpleToken.forwardSlash(0);
+    expect(token.lexeme, '/');
+    expect(token.end, 1);
+    expect(token.length, 1);
+    expect(token.offset, 0);
+    expect(token.type, NgSimpleTokenType.forwardSlash);
+  });
+
+  test('hash', () {
+    token = new NgSimpleToken.hash(0);
+    expect(token.lexeme, '#');
+    expect(token.end, 1);
+    expect(token.length, 1);
+    expect(token.offset, 0);
+    expect(token.type, NgSimpleTokenType.hash);
+  });
+
+  test('identifier', () {
+    token = new NgSimpleToken.identifier(0, 'some_tag_identifier');
+    expect(token.lexeme, 'some_tag_identifier');
+    expect(token.end, 19);
+    expect(token.length, 19);
+    expect(token.offset, 0);
+    expect(token.type, NgSimpleTokenType.identifier);
+  });
+
+  test('openBracket', () {
+    token = new NgSimpleToken.openBracket(0);
+    expect(token.lexeme, '[');
+    expect(token.end, 1);
+    expect(token.length, 1);
+    expect(token.offset, 0);
+    expect(token.type, NgSimpleTokenType.openBracket);
+  });
+
+  test('openParen', () {
+    token = new NgSimpleToken.openParen(0);
+    expect(token.lexeme, '(');
+    expect(token.end, 1);
+    expect(token.length, 1);
+    expect(token.offset, 0);
+    expect(token.type, NgSimpleTokenType.openParen);
+  });
+
+  test('period', () {
+    token = new NgSimpleToken.period(0);
+    expect(token.lexeme, '.');
+    expect(token.end, 1);
+    expect(token.length, 1);
+    expect(token.offset, 0);
+    expect(token.type, NgSimpleTokenType.period);
+  });
+
+  test('star', () {
+    token = new NgSimpleToken.star(0);
+    expect(token.end, 1);
+    expect(token.length, 1);
+    expect(token.offset, 0);
+    expect(token.type, NgSimpleTokenType.star);
+  });
+
+  test('text', () {
+    token = new NgSimpleToken.text(0, 'some long text string');
+    expect(token.lexeme, 'some long text string');
+    expect(token.end, 21);
+    expect(token.length, 21);
+    expect(token.offset, 0);
+    expect(token.type, NgSimpleTokenType.text);
+  });
+
+  test('unexpectedChar', () {
+    token = new NgSimpleToken.unexpectedChar(0, '!@#\$');
+    expect(token.lexeme, '!@#\$');
+    expect(token.end, 4);
+    expect(token.length, 4);
+    expect(token.offset, 0);
+    expect(token.type, NgSimpleTokenType.unexpectedChar);
+  });
+
+  test('whitespace', () {
+    token = new NgSimpleToken.whitespace(0, '     \t\t\n');
+    expect(token.lexeme, '     \t\t\n');
+    expect(token.end, 8);
+    expect(token.length, 8);
+    expect(token.offset, 0);
+    expect(token.type, NgSimpleTokenType.whitespace);
+  });
+
+  test('doubleQuotedText - closed', () {
+    NgSimpleQuoteToken quoteToken = new NgSimpleQuoteToken.doubleQuotedText(
+        0, '"this is a \"quoted\" text"', true);
+    expect(quoteToken.lexeme, 'this is a \"quoted\" text');
+    expect(quoteToken.end, 24);
+    expect(quoteToken.length, 23);
+    expect(quoteToken.offset, 1);
+    expect(quoteToken.quoteEndOffset, 25);
+    expect(quoteToken.quoteOffset, 0);
+    expect(quoteToken.quotedLexeme, '"this is a \"quoted\" text"');
+    expect(quoteToken.quotedLength, 25);
+    expect(quoteToken.type, NgSimpleTokenType.doubleQuote);
+  });
+
+  test('doubleQuotedText - open', () {
+    NgSimpleQuoteToken quoteToken = new NgSimpleQuoteToken.doubleQuotedText(
+        0, '"this is a \"quoted\" text', false);
+    expect(quoteToken.lexeme, 'this is a \"quoted\" text');
+    expect(quoteToken.end, 24);
+    expect(quoteToken.length, 23);
+    expect(quoteToken.offset, 1);
+    expect(quoteToken.quoteEndOffset, null);
+    expect(quoteToken.quoteOffset, 0);
+    expect(quoteToken.quotedLexeme, '"this is a \"quoted\" text');
+    expect(quoteToken.quotedLength, 24);
+    expect(quoteToken.type, NgSimpleTokenType.doubleQuote);
+  });
+
+  test('singleQuotedText - closed', () {
+    NgSimpleQuoteToken quoteToken = new NgSimpleQuoteToken.singleQuotedText(
+        0, "'this is a \'quoted\' text'", true);
+    expect(quoteToken.lexeme, "this is a \'quoted\' text");
+    expect(quoteToken.end, 24);
+    expect(quoteToken.length, 23);
+    expect(quoteToken.offset, 1);
+    expect(quoteToken.quoteEndOffset, 25);
+    expect(quoteToken.quoteOffset, 0);
+    expect(quoteToken.quotedLexeme, "'this is a \'quoted\' text'");
+    expect(quoteToken.quotedLength, 25);
+    expect(quoteToken.type, NgSimpleTokenType.singleQuote);
+  });
+
+  test('doubleQuotedText - open', () {
+    NgSimpleQuoteToken quoteToken = new NgSimpleQuoteToken.singleQuotedText(
+        0, "'this is a \'quoted\' text", false);
+    expect(quoteToken.lexeme, "this is a \'quoted\' text");
+    expect(quoteToken.end, 24);
+    expect(quoteToken.length, 23);
+    expect(quoteToken.offset, 1);
+    expect(quoteToken.quoteEndOffset, null);
+    expect(quoteToken.quoteOffset, 0);
+    expect(quoteToken.quotedLexeme, "'this is a \'quoted\' text");
+    expect(quoteToken.quotedLength, 24);
+    expect(quoteToken.type, NgSimpleTokenType.singleQuote);
+  });
+}

--- a/test/simple_tokenizer_test.dart
+++ b/test/simple_tokenizer_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -12,16 +12,6 @@ void main() {
   String untokenize(Iterable<NgSimpleToken> tokens) => tokens
       .fold(new StringBuffer(), (buffer, token) => buffer..write(token.lexeme))
       .toString();
-
-  /**
-  test('', () {
-    expect(
-      tokenize(''),
-      [
-      ]
-    );
-  });
-  **/
 
   test('should tokenize plain text', () {
     expect(tokenize('Hello World'), [

--- a/test/simple_tokenizer_test.dart
+++ b/test/simple_tokenizer_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 
 void main() {
   Iterable<NgSimpleToken> tokenize(String html) =>
-      new NgSimpleTokenizer(html).tokenize();
+      new NgSimpleTokenizer().tokenize(html);
   String untokenize(Iterable<NgSimpleToken> tokens) => tokens
       .fold(new StringBuffer(), (buffer, token) => buffer..write(token.lexeme))
       .toString();

--- a/test/simple_tokenizer_test.dart
+++ b/test/simple_tokenizer_test.dart
@@ -3,19 +3,89 @@ import 'package:angular_ast/src/simple_token.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('should greedily parse only text nodes', () {
+  NgSimpleToken tokenize(String html) => new NgSimpleScanner(html).scan();
+  NgSimpleToken tokenizeTag(String html) =>
+      new NgSimpleScanner(html, initialTextState: false).scan();
+
+  //Text node
+  test('text node: should tokenize text', () {
     expect(
-      new NgSimpleScanner("some random text <div>").scan(),
-      new NgSimpleToken.text(0, "some random text"),
+      tokenize("some random text <div></div>"),
+      new NgSimpleToken.text(0, "some random text "),
     );
   });
 
-  test('should parse only an elementStart tag', () {
-    expect(new NgSimpleScanner("<div></div>").scan(),
-        new NgSimpleToken.elementStart(0));
+  test('text node: should tokenize elementStart tag', () {
+    expect(tokenize("<div></div>"), new NgSimpleToken.elementStart(0));
   });
 
-  test('should parse end of file', () {
+  test('text node: should tokenize EOF', () {
     expect(new NgSimpleScanner("").scan(), new NgSimpleToken.EOF(0));
+  });
+
+  //Element node
+  test('element: should tokenize end bracket', () {
+    expect(tokenizeTag("]='someAttrValue'"), new NgSimpleToken.closeBracket(0));
+  });
+
+  test('element: should tokenize single bang', () {
+    expect(tokenizeTag("!-- some comment tag -->"), new NgSimpleToken.bang(0));
+  });
+
+  test('element: should tokenize single dash', () {
+    expect(tokenizeTag("-- some comment tag -->"), new NgSimpleToken.dash(0));
+  });
+
+  test('element: should tokenize closeParen', () {
+    expect(tokenizeTag(")='someAttrValue'"), new NgSimpleToken.closeParen(0));
+  });
+
+  test('element: should tokenze elementEnd', () {
+    expect(tokenizeTag("> some text </div>"), new NgSimpleToken.elementEnd(0));
+  });
+
+  test('element: should tokenize forwardSlash', () {
+    expect(tokenizeTag("/><div></div>"), new NgSimpleToken.forwardSlash(0));
+  });
+
+  test('element: should tokenize openBracket', () {
+    expect(tokenizeTag("[someInput]='blah'"), new NgSimpleToken.openBracket(0));
+  });
+
+  test('element: should tokenize openParen', () {
+    expect(tokenizeTag("(someEvent)='do something;'"),
+        new NgSimpleToken.openParen(0));
+  });
+
+  test('element: should tokenize whiteSpace', () {
+    expect(tokenizeTag("  someAttr='blah'"),
+        new NgSimpleToken.whitespace(0, "  "));
+  });
+
+  test('element: should tokenize text', () {
+    expect(tokenizeTag("my-element_tag [a]='y'>"),
+        new NgSimpleToken.text(0, "my-element_tag"));
+  });
+
+  test('element: should tokenize doubleQuoted text', () {
+    expect(tokenizeTag('"doSomething1; doSomething2"'),
+        new NgSimpleToken.doubleQuotedText(0, '"doSomething1; doSomething2"'));
+  });
+
+  test('element: should tokenize singleQuoted text', () {
+    expect(tokenizeTag("'doSomething1; doSomething2'"),
+        new NgSimpleToken.singleQuotedText(0, "'doSomething1; doSomething2'"));
+  });
+
+  test('element: should tokenize unclosed doubleQuote', () {
+    expect(tokenizeTag('" blah blah'), new NgSimpleToken.doubleQuote(0));
+  });
+
+  test('element: should tokenize unclosed singleQuote', () {
+    expect(tokenizeTag("' blah blah"), new NgSimpleToken.singleQuote(0));
+  });
+
+  test('element: should tokenize elementStart tag', () {
+    expect(tokenizeTag("<div></div>"), new NgSimpleToken.elementStart(0));
   });
 }

--- a/test/simple_tokenizer_test.dart
+++ b/test/simple_tokenizer_test.dart
@@ -165,23 +165,20 @@ void main() {
   });
 
   test('should tokenize asterisks', () {
-    expect(
-        tokenize('<span *ngIf="some bool"></span>'),
-        [
-          new NgSimpleToken.tagStart(0),
-          new NgSimpleToken.text(1, "span"),
-          new NgSimpleToken.whitespace(5, ' '),
-          new NgSimpleToken.star(6),
-          new NgSimpleToken.text(7, 'ngIf'),
-          new NgSimpleToken.equalSign(11),
-          new NgSimpleToken.doubleQuotedText(12, '"some bool"'),
-          new NgSimpleToken.tagEnd(23),
-          new NgSimpleToken.tagStart(24),
-          new NgSimpleToken.forwardSlash(25),
-          new NgSimpleToken.text(26, 'span'),
-          new NgSimpleToken.tagEnd(30)
-        ]
-    );
+    expect(tokenize('<span *ngIf="some bool"></span>'), [
+      new NgSimpleToken.tagStart(0),
+      new NgSimpleToken.text(1, "span"),
+      new NgSimpleToken.whitespace(5, ' '),
+      new NgSimpleToken.star(6),
+      new NgSimpleToken.text(7, 'ngIf'),
+      new NgSimpleToken.equalSign(11),
+      new NgSimpleToken.doubleQuotedText(12, '"some bool"'),
+      new NgSimpleToken.tagEnd(23),
+      new NgSimpleToken.tagStart(24),
+      new NgSimpleToken.forwardSlash(25),
+      new NgSimpleToken.text(26, 'span'),
+      new NgSimpleToken.tagEnd(30)
+    ]);
   });
 
   //Error cases
@@ -197,92 +194,76 @@ void main() {
             4,
             '\n  Copyright (c) 2016, the Dart project authors.\n',
           ),
-        ]
-    );
+        ]);
   });
 
   test('should tokenize unclosed element tag hitting EOF', () {
-    expect(
-        tokenize('<div '),
-        [
-          new NgSimpleToken.tagStart(0),
-          new NgSimpleToken.text(1, 'div'),
-          new NgSimpleToken.whitespace(4, ' ')
-        ]
-    );
+    expect(tokenize('<div '), [
+      new NgSimpleToken.tagStart(0),
+      new NgSimpleToken.text(1, 'div'),
+      new NgSimpleToken.whitespace(4, ' ')
+    ]);
   });
 
   test('should tokenize unclosed element tags', () {
     expect(
         tokenize(''
-          '<div>'
+            '<div>'
             ' some text stuff here '
             '<span'
-          '</div>'),
+            '</div>'),
         [
           new NgSimpleToken.tagStart(0),
-          new NgSimpleToken.text(1,'div'),
+          new NgSimpleToken.text(1, 'div'),
           new NgSimpleToken.tagEnd(4),
           new NgSimpleToken.text(5, ' some text stuff here '),
           new NgSimpleToken.tagStart(27),
-          new NgSimpleToken.text(28,'span'),
+          new NgSimpleToken.text(28, 'span'),
           new NgSimpleToken.tagStart(32),
           new NgSimpleToken.forwardSlash(33),
           new NgSimpleToken.text(34, 'div'),
           new NgSimpleToken.tagEnd(37)
-        ]
-    );
+        ]);
   });
 
-
   test('should tokenize dangling double quote', () {
-    expect(
-        tokenize('''<div [someInput]=" (someEvent)='do something'>'''),
-        [
-          new NgSimpleToken.tagStart(0),
-          new NgSimpleToken.text(1, 'div'),
-          new NgSimpleToken.whitespace(4, ' '),
-          new NgSimpleToken.openBracket(5),
-          new NgSimpleToken.text(6, 'someInput'),
-          new NgSimpleToken.closeBracket(15),
-          new NgSimpleToken.equalSign(16),
-          new NgSimpleToken.doubleQuote(17),
-          new NgSimpleToken.whitespace(18, ' '),
-          new NgSimpleToken.openParen(19),
-          new NgSimpleToken.text(20, 'someEvent'),
-          new NgSimpleToken.closeParen(29),
-          new NgSimpleToken.equalSign(30),
-          new NgSimpleToken.singleQuotedText(31, "'do something'"),
-          new NgSimpleToken.tagEnd(45)
-        ]
-    );
+    expect(tokenize('''<div [someInput]=" (someEvent)='do something'>'''), [
+      new NgSimpleToken.tagStart(0),
+      new NgSimpleToken.text(1, 'div'),
+      new NgSimpleToken.whitespace(4, ' '),
+      new NgSimpleToken.openBracket(5),
+      new NgSimpleToken.text(6, 'someInput'),
+      new NgSimpleToken.closeBracket(15),
+      new NgSimpleToken.equalSign(16),
+      new NgSimpleToken.doubleQuote(17),
+      new NgSimpleToken.whitespace(18, ' '),
+      new NgSimpleToken.openParen(19),
+      new NgSimpleToken.text(20, 'someEvent'),
+      new NgSimpleToken.closeParen(29),
+      new NgSimpleToken.equalSign(30),
+      new NgSimpleToken.singleQuotedText(31, "'do something'"),
+      new NgSimpleToken.tagEnd(45)
+    ]);
   });
 
   test('should tokenize unclosed attr hitting EOF', () {
-    expect(
-        tokenize('<div someAttr '),
-        [
-          new NgSimpleToken.tagStart(0),
-          new NgSimpleToken.text(1, 'div'),
-          new NgSimpleToken.whitespace(4, ' '),
-          new NgSimpleToken.text(5, 'someAttr'),
-          new NgSimpleToken.whitespace(13, ' '),
-        ]
-    );
+    expect(tokenize('<div someAttr '), [
+      new NgSimpleToken.tagStart(0),
+      new NgSimpleToken.text(1, 'div'),
+      new NgSimpleToken.whitespace(4, ' '),
+      new NgSimpleToken.text(5, 'someAttr'),
+      new NgSimpleToken.whitespace(13, ' '),
+    ]);
   });
 
   test('should tokenize unclosed attr value hitting EOF', () {
-    expect(
-        tokenize('<div someAttr ='),
-        [
-          new NgSimpleToken.tagStart(0),
-          new NgSimpleToken.text(1, 'div'),
-          new NgSimpleToken.whitespace(4, ' '),
-          new NgSimpleToken.text(5, 'someAttr'),
-          new NgSimpleToken.whitespace(13, ' '),
-          new NgSimpleToken.equalSign(14),
-        ]
-    );
+    expect(tokenize('<div someAttr ='), [
+      new NgSimpleToken.tagStart(0),
+      new NgSimpleToken.text(1, 'div'),
+      new NgSimpleToken.whitespace(4, ' '),
+      new NgSimpleToken.text(5, 'someAttr'),
+      new NgSimpleToken.whitespace(13, ' '),
+      new NgSimpleToken.equalSign(14),
+    ]);
   });
-
 }

--- a/test/simple_tokenizer_test.dart
+++ b/test/simple_tokenizer_test.dart
@@ -27,26 +27,38 @@ void main() {
   test('should tokenize an HTML element', () {
     expect(tokenize('''<div></div>'''), [
       new NgSimpleToken.tagStart(0),
-      new NgSimpleToken.text(1, 'div'),
+      new NgSimpleToken.identifier(1, 'div'),
       new NgSimpleToken.tagEnd(4),
       new NgSimpleToken.tagStart(5),
       new NgSimpleToken.forwardSlash(6),
-      new NgSimpleToken.text(7, 'div'),
+      new NgSimpleToken.identifier(7, 'div'),
       new NgSimpleToken.tagEnd(10)
+    ]);
+  });
+
+  test('should tokenize an HTML element with dash', () {
+    expect(tokenize('''<my-tag></my-tag>'''), [
+      new NgSimpleToken.tagStart(0),
+      new NgSimpleToken.dashedIdentifier(1, 'my-tag'),
+      new NgSimpleToken.tagEnd(7),
+      new NgSimpleToken.tagStart(8),
+      new NgSimpleToken.forwardSlash(9),
+      new NgSimpleToken.dashedIdentifier(10, 'my-tag'),
+      new NgSimpleToken.tagEnd(16)
     ]);
   });
 
   test('should tokenize an HTML element with local variable', () {
     expect(tokenize('''<div #myDiv></div>'''), [
       new NgSimpleToken.tagStart(0),
-      new NgSimpleToken.text(1, 'div'),
+      new NgSimpleToken.identifier(1, 'div'),
       new NgSimpleToken.whitespace(4, ' '),
       new NgSimpleToken.hash(5),
-      new NgSimpleToken.text(6, 'myDiv'),
+      new NgSimpleToken.identifier(6, 'myDiv'),
       new NgSimpleToken.tagEnd(11),
       new NgSimpleToken.tagStart(12),
       new NgSimpleToken.forwardSlash(13),
-      new NgSimpleToken.text(14, 'div'),
+      new NgSimpleToken.identifier(14, 'div'),
       new NgSimpleToken.tagEnd(17)
     ]);
   });
@@ -54,7 +66,7 @@ void main() {
   test('should tokenize an HTML element with void', () {
     expect(tokenize('<hr/>'), [
       new NgSimpleToken.tagStart(0),
-      new NgSimpleToken.text(1, "hr"),
+      new NgSimpleToken.identifier(1, "hr"),
       new NgSimpleToken.forwardSlash(3),
       new NgSimpleToken.tagEnd(4)
     ]);
@@ -63,18 +75,18 @@ void main() {
   test('should tokenize nested HTML elements', () {
     expect(tokenize('<div><span></span></div>'), [
       new NgSimpleToken.tagStart(0),
-      new NgSimpleToken.text(1, 'div'),
+      new NgSimpleToken.identifier(1, 'div'),
       new NgSimpleToken.tagEnd(4),
       new NgSimpleToken.tagStart(5),
-      new NgSimpleToken.text(6, 'span'),
+      new NgSimpleToken.identifier(6, 'span'),
       new NgSimpleToken.tagEnd(10),
       new NgSimpleToken.tagStart(11),
       new NgSimpleToken.forwardSlash(12),
-      new NgSimpleToken.text(13, 'span'),
+      new NgSimpleToken.identifier(13, 'span'),
       new NgSimpleToken.tagEnd(17),
       new NgSimpleToken.tagStart(18),
       new NgSimpleToken.forwardSlash(19),
-      new NgSimpleToken.text(20, 'div'),
+      new NgSimpleToken.identifier(20, 'div'),
       new NgSimpleToken.tagEnd(23)
     ]);
   });
@@ -82,12 +94,12 @@ void main() {
   test('should tokenize HTML elements mixed with plain text', () {
     expect(tokenize('<div>Hello this is text</div>'), [
       new NgSimpleToken.tagStart(0),
-      new NgSimpleToken.text(1, 'div'),
+      new NgSimpleToken.identifier(1, 'div'),
       new NgSimpleToken.tagEnd(4),
       new NgSimpleToken.text(5, 'Hello this is text'),
       new NgSimpleToken.tagStart(23),
       new NgSimpleToken.forwardSlash(24),
-      new NgSimpleToken.text(25, 'div'),
+      new NgSimpleToken.identifier(25, 'div'),
       new NgSimpleToken.tagEnd(28)
     ]);
   });
@@ -111,16 +123,37 @@ void main() {
   test('should tokenize an element with a decorator with a value', () {
     expect(tokenize(r'<button title="Submit \"quoted text\""></button>'), [
       new NgSimpleToken.tagStart(0),
-      new NgSimpleToken.text(1, 'button'),
+      new NgSimpleToken.identifier(1, 'button'),
       new NgSimpleToken.whitespace(7, ' '),
-      new NgSimpleToken.text(8, 'title'),
+      new NgSimpleToken.identifier(8, 'title'),
       new NgSimpleToken.equalSign(13),
       new NgSimpleToken.doubleQuotedText(14, '"Submit \"quoted text\""'),
       new NgSimpleToken.tagEnd(38),
       new NgSimpleToken.tagStart(39),
       new NgSimpleToken.forwardSlash(40),
-      new NgSimpleToken.text(41, 'button'),
+      new NgSimpleToken.identifier(41, 'button'),
       new NgSimpleToken.tagEnd(47)
+    ]);
+  });
+
+  test('should tokenize an HTML element with bracket and period in decorator',
+      () {
+    expect(tokenize('''<my-tag [attr.x]="y"></my-tag>'''), [
+      new NgSimpleToken.tagStart(0),
+      new NgSimpleToken.dashedIdentifier(1, 'my-tag'),
+      new NgSimpleToken.whitespace(7, ' '),
+      new NgSimpleToken.openBracket(8),
+      new NgSimpleToken.identifier(9, 'attr'),
+      new NgSimpleToken.period(13),
+      new NgSimpleToken.identifier(14, 'x'),
+      new NgSimpleToken.closeBracket(15),
+      new NgSimpleToken.equalSign(16),
+      new NgSimpleToken.doubleQuotedText(17, '"y"'),
+      new NgSimpleToken.tagEnd(20),
+      new NgSimpleToken.tagStart(21),
+      new NgSimpleToken.forwardSlash(22),
+      new NgSimpleToken.dashedIdentifier(23, 'my-tag'),
+      new NgSimpleToken.tagEnd(29)
     ]);
   });
 
@@ -137,7 +170,7 @@ void main() {
           </li>
           <li>
             <myTag myAttr="some value "literal""></myTag>
-            <button disabled>3</button>
+            <button disabled [attr.x]="y">3</button>
           </li>
         </ul>
       </div>
@@ -173,16 +206,16 @@ void main() {
   test('should tokenize asterisks', () {
     expect(tokenize('<span *ngIf="some bool"></span>'), [
       new NgSimpleToken.tagStart(0),
-      new NgSimpleToken.text(1, "span"),
+      new NgSimpleToken.identifier(1, "span"),
       new NgSimpleToken.whitespace(5, ' '),
       new NgSimpleToken.star(6),
-      new NgSimpleToken.text(7, 'ngIf'),
+      new NgSimpleToken.identifier(7, 'ngIf'),
       new NgSimpleToken.equalSign(11),
       new NgSimpleToken.doubleQuotedText(12, '"some bool"'),
       new NgSimpleToken.tagEnd(23),
       new NgSimpleToken.tagStart(24),
       new NgSimpleToken.forwardSlash(25),
-      new NgSimpleToken.text(26, 'span'),
+      new NgSimpleToken.identifier(26, 'span'),
       new NgSimpleToken.tagEnd(30)
     ]);
   });
@@ -206,7 +239,7 @@ void main() {
   test('should tokenize unclosed element tag hitting EOF', () {
     expect(tokenize('<div '), [
       new NgSimpleToken.tagStart(0),
-      new NgSimpleToken.text(1, 'div'),
+      new NgSimpleToken.identifier(1, 'div'),
       new NgSimpleToken.whitespace(4, ' ')
     ]);
   });
@@ -220,14 +253,14 @@ void main() {
             '</div>'),
         [
           new NgSimpleToken.tagStart(0),
-          new NgSimpleToken.text(1, 'div'),
+          new NgSimpleToken.identifier(1, 'div'),
           new NgSimpleToken.tagEnd(4),
           new NgSimpleToken.text(5, ' some text stuff here '),
           new NgSimpleToken.tagStart(27),
-          new NgSimpleToken.text(28, 'span'),
+          new NgSimpleToken.identifier(28, 'span'),
           new NgSimpleToken.tagStart(32),
           new NgSimpleToken.forwardSlash(33),
-          new NgSimpleToken.text(34, 'div'),
+          new NgSimpleToken.identifier(34, 'div'),
           new NgSimpleToken.tagEnd(37)
         ]);
   });
@@ -235,16 +268,16 @@ void main() {
   test('should tokenize dangling double quote', () {
     expect(tokenize('''<div [someInput]=" (someEvent)='do something'>'''), [
       new NgSimpleToken.tagStart(0),
-      new NgSimpleToken.text(1, 'div'),
+      new NgSimpleToken.identifier(1, 'div'),
       new NgSimpleToken.whitespace(4, ' '),
       new NgSimpleToken.openBracket(5),
-      new NgSimpleToken.text(6, 'someInput'),
+      new NgSimpleToken.identifier(6, 'someInput'),
       new NgSimpleToken.closeBracket(15),
       new NgSimpleToken.equalSign(16),
       new NgSimpleToken.doubleQuote(17),
       new NgSimpleToken.whitespace(18, ' '),
       new NgSimpleToken.openParen(19),
-      new NgSimpleToken.text(20, 'someEvent'),
+      new NgSimpleToken.identifier(20, 'someEvent'),
       new NgSimpleToken.closeParen(29),
       new NgSimpleToken.equalSign(30),
       new NgSimpleToken.singleQuotedText(31, "'do something'"),
@@ -255,9 +288,9 @@ void main() {
   test('should tokenize unclosed attr hitting EOF', () {
     expect(tokenize('<div someAttr '), [
       new NgSimpleToken.tagStart(0),
-      new NgSimpleToken.text(1, 'div'),
+      new NgSimpleToken.identifier(1, 'div'),
       new NgSimpleToken.whitespace(4, ' '),
-      new NgSimpleToken.text(5, 'someAttr'),
+      new NgSimpleToken.identifier(5, 'someAttr'),
       new NgSimpleToken.whitespace(13, ' '),
     ]);
   });
@@ -265,9 +298,9 @@ void main() {
   test('should tokenize unclosed attr value hitting EOF', () {
     expect(tokenize('<div someAttr ='), [
       new NgSimpleToken.tagStart(0),
-      new NgSimpleToken.text(1, 'div'),
+      new NgSimpleToken.identifier(1, 'div'),
       new NgSimpleToken.whitespace(4, ' '),
-      new NgSimpleToken.text(5, 'someAttr'),
+      new NgSimpleToken.identifier(5, 'someAttr'),
       new NgSimpleToken.whitespace(13, ' '),
       new NgSimpleToken.equalSign(14),
     ]);

--- a/test/simple_tokenizer_test.dart
+++ b/test/simple_tokenizer_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:angular_ast/src/simple_tokenizer.dart';
 import 'package:angular_ast/src/simple_token.dart';
 import 'package:test/test.dart';
@@ -159,4 +163,126 @@ void main() {
       ],
     );
   });
+
+  test('should tokenize asterisks', () {
+    expect(
+        tokenize('<span *ngIf="some bool"></span>'),
+        [
+          new NgSimpleToken.tagStart(0),
+          new NgSimpleToken.text(1, "span"),
+          new NgSimpleToken.whitespace(5, ' '),
+          new NgSimpleToken.star(6),
+          new NgSimpleToken.text(7, 'ngIf'),
+          new NgSimpleToken.equalSign(11),
+          new NgSimpleToken.doubleQuotedText(12, '"some bool"'),
+          new NgSimpleToken.tagEnd(23),
+          new NgSimpleToken.tagStart(24),
+          new NgSimpleToken.forwardSlash(25),
+          new NgSimpleToken.text(26, 'span'),
+          new NgSimpleToken.tagEnd(30)
+        ]
+    );
+  });
+
+  //Error cases
+
+  test('should tokenize unclosed comments', () {
+    expect(
+        tokenize(''
+            '<!--\n'
+            '  Copyright (c) 2016, the Dart project authors.\n'),
+        [
+          new NgSimpleToken.commentBegin(0),
+          new NgSimpleToken.text(
+            4,
+            '\n  Copyright (c) 2016, the Dart project authors.\n',
+          ),
+        ]
+    );
+  });
+
+  test('should tokenize unclosed element tag hitting EOF', () {
+    expect(
+        tokenize('<div '),
+        [
+          new NgSimpleToken.tagStart(0),
+          new NgSimpleToken.text(1, 'div'),
+          new NgSimpleToken.whitespace(4, ' ')
+        ]
+    );
+  });
+
+  test('should tokenize unclosed element tags', () {
+    expect(
+        tokenize(''
+          '<div>'
+            ' some text stuff here '
+            '<span'
+          '</div>'),
+        [
+          new NgSimpleToken.tagStart(0),
+          new NgSimpleToken.text(1,'div'),
+          new NgSimpleToken.tagEnd(4),
+          new NgSimpleToken.text(5, ' some text stuff here '),
+          new NgSimpleToken.tagStart(27),
+          new NgSimpleToken.text(28,'span'),
+          new NgSimpleToken.tagStart(32),
+          new NgSimpleToken.forwardSlash(33),
+          new NgSimpleToken.text(34, 'div'),
+          new NgSimpleToken.tagEnd(37)
+        ]
+    );
+  });
+
+
+  test('should tokenize dangling double quote', () {
+    expect(
+        tokenize('''<div [someInput]=" (someEvent)='do something'>'''),
+        [
+          new NgSimpleToken.tagStart(0),
+          new NgSimpleToken.text(1, 'div'),
+          new NgSimpleToken.whitespace(4, ' '),
+          new NgSimpleToken.openBracket(5),
+          new NgSimpleToken.text(6, 'someInput'),
+          new NgSimpleToken.closeBracket(15),
+          new NgSimpleToken.equalSign(16),
+          new NgSimpleToken.doubleQuote(17),
+          new NgSimpleToken.whitespace(18, ' '),
+          new NgSimpleToken.openParen(19),
+          new NgSimpleToken.text(20, 'someEvent'),
+          new NgSimpleToken.closeParen(29),
+          new NgSimpleToken.equalSign(30),
+          new NgSimpleToken.singleQuotedText(31, "'do something'"),
+          new NgSimpleToken.tagEnd(45)
+        ]
+    );
+  });
+
+  test('should tokenize unclosed attr hitting EOF', () {
+    expect(
+        tokenize('<div someAttr '),
+        [
+          new NgSimpleToken.tagStart(0),
+          new NgSimpleToken.text(1, 'div'),
+          new NgSimpleToken.whitespace(4, ' '),
+          new NgSimpleToken.text(5, 'someAttr'),
+          new NgSimpleToken.whitespace(13, ' '),
+        ]
+    );
+  });
+
+  test('should tokenize unclosed attr value hitting EOF', () {
+    expect(
+        tokenize('<div someAttr ='),
+        [
+          new NgSimpleToken.tagStart(0),
+          new NgSimpleToken.text(1, 'div'),
+          new NgSimpleToken.whitespace(4, ' '),
+          new NgSimpleToken.text(5, 'someAttr'),
+          new NgSimpleToken.whitespace(13, ' '),
+          new NgSimpleToken.equalSign(14),
+        ]
+    );
+  });
+
 }

--- a/test/simple_tokenizer_test.dart
+++ b/test/simple_tokenizer_test.dart
@@ -36,6 +36,21 @@ void main() {
     ]);
   });
 
+  test('should tokenize an HTML element with local variable', () {
+    expect(tokenize('''<div #myDiv></div>'''), [
+      new NgSimpleToken.tagStart(0),
+      new NgSimpleToken.text(1, 'div'),
+      new NgSimpleToken.whitespace(4, ' '),
+      new NgSimpleToken.hash(5),
+      new NgSimpleToken.text(6, 'myDiv'),
+      new NgSimpleToken.tagEnd(11),
+      new NgSimpleToken.tagStart(12),
+      new NgSimpleToken.forwardSlash(13),
+      new NgSimpleToken.text(14, 'div'),
+      new NgSimpleToken.tagEnd(17)
+    ]);
+  });
+
   test('should tokenize an HTML element with void', () {
     expect(tokenize('<hr/>'), [
       new NgSimpleToken.tagStart(0),
@@ -94,18 +109,18 @@ void main() {
   });
 
   test('should tokenize an element with a decorator with a value', () {
-    expect(tokenize('<button title="Submit"></button>'), [
+    expect(tokenize(r'<button title="Submit \"quoted text\""></button>'), [
       new NgSimpleToken.tagStart(0),
       new NgSimpleToken.text(1, 'button'),
       new NgSimpleToken.whitespace(7, ' '),
       new NgSimpleToken.text(8, 'title'),
       new NgSimpleToken.equalSign(13),
-      new NgSimpleToken.doubleQuotedText(14, '"Submit"'),
-      new NgSimpleToken.tagEnd(22),
-      new NgSimpleToken.tagStart(23),
-      new NgSimpleToken.forwardSlash(24),
-      new NgSimpleToken.text(25, 'button'),
-      new NgSimpleToken.tagEnd(31)
+      new NgSimpleToken.doubleQuotedText(14, '"Submit \"quoted text\""'),
+      new NgSimpleToken.tagEnd(38),
+      new NgSimpleToken.tagStart(39),
+      new NgSimpleToken.forwardSlash(40),
+      new NgSimpleToken.text(41, 'button'),
+      new NgSimpleToken.tagEnd(47)
     ]);
   });
 
@@ -121,6 +136,7 @@ void main() {
             <textarea disabled name="box" readonly>Test</textarea>
           </li>
           <li>
+            <myTag myAttr="some value "literal""></myTag>
             <button disabled>3</button>
           </li>
         </ul>

--- a/test/simple_tokenizer_test.dart
+++ b/test/simple_tokenizer_test.dart
@@ -10,7 +10,12 @@ void main() {
   Iterable<NgSimpleToken> tokenize(String html) =>
       new NgSimpleTokenizer().tokenize(html);
   String untokenize(Iterable<NgSimpleToken> tokens) => tokens
-      .fold(new StringBuffer(), (buffer, token) => buffer..write(token.lexeme))
+      .fold(
+          new StringBuffer(),
+          (buffer, token) => buffer
+            ..write((token is NgSimpleQuoteToken)
+                ? token.quotedLexeme
+                : token.lexeme))
       .toString();
 
   test('should tokenize plain text', () {
@@ -127,7 +132,8 @@ void main() {
       new NgSimpleToken.whitespace(7, ' '),
       new NgSimpleToken.identifier(8, 'title'),
       new NgSimpleToken.equalSign(13),
-      new NgSimpleToken.doubleQuotedText(14, '"Submit \"quoted text\""'),
+      new NgSimpleQuoteToken.doubleQuotedText(
+          14, '"Submit \"quoted text\""', true),
       new NgSimpleToken.tagEnd(38),
       new NgSimpleToken.tagStart(39),
       new NgSimpleToken.forwardSlash(40),
@@ -148,7 +154,7 @@ void main() {
       new NgSimpleToken.identifier(14, 'x'),
       new NgSimpleToken.closeBracket(15),
       new NgSimpleToken.equalSign(16),
-      new NgSimpleToken.doubleQuotedText(17, '"y"'),
+      new NgSimpleQuoteToken.doubleQuotedText(17, '"y"', true),
       new NgSimpleToken.tagEnd(20),
       new NgSimpleToken.tagStart(21),
       new NgSimpleToken.forwardSlash(22),
@@ -211,7 +217,7 @@ void main() {
       new NgSimpleToken.star(6),
       new NgSimpleToken.identifier(7, 'ngIf'),
       new NgSimpleToken.equalSign(11),
-      new NgSimpleToken.doubleQuotedText(12, '"some bool"'),
+      new NgSimpleQuoteToken.doubleQuotedText(12, '"some bool"', true),
       new NgSimpleToken.tagEnd(23),
       new NgSimpleToken.tagStart(24),
       new NgSimpleToken.forwardSlash(25),
@@ -274,14 +280,22 @@ void main() {
       new NgSimpleToken.identifier(6, 'someInput'),
       new NgSimpleToken.closeBracket(15),
       new NgSimpleToken.equalSign(16),
-      new NgSimpleToken.doubleQuote(17),
-      new NgSimpleToken.whitespace(18, ' '),
-      new NgSimpleToken.openParen(19),
-      new NgSimpleToken.identifier(20, 'someEvent'),
-      new NgSimpleToken.closeParen(29),
-      new NgSimpleToken.equalSign(30),
-      new NgSimpleToken.singleQuotedText(31, "'do something'"),
-      new NgSimpleToken.tagEnd(45)
+      new NgSimpleQuoteToken.doubleQuotedText(
+          17, '" (someEvent)=\'do something\'>', false),
+    ]);
+  });
+
+  test('should tokenize dangling single quote', () {
+    expect(tokenize('''<div [someInput]=' (someEvent)="do something">'''), [
+      new NgSimpleToken.tagStart(0),
+      new NgSimpleToken.identifier(1, 'div'),
+      new NgSimpleToken.whitespace(4, ' '),
+      new NgSimpleToken.openBracket(5),
+      new NgSimpleToken.identifier(6, 'someInput'),
+      new NgSimpleToken.closeBracket(15),
+      new NgSimpleToken.equalSign(16),
+      new NgSimpleQuoteToken.singleQuotedText(
+          17, "' (someEvent)=\"do something\">", false),
     ]);
   });
 

--- a/test/simple_tokenizer_test.dart
+++ b/test/simple_tokenizer_test.dart
@@ -1,0 +1,21 @@
+import 'package:angular_ast/src/simple_tokenizer.dart';
+import 'package:angular_ast/src/simple_token.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('should greedily parse only text nodes', () {
+    expect(
+      new NgSimpleScanner("some random text <div>").scan(),
+      new NgSimpleToken.text(0, "some random text"),
+    );
+  });
+
+  test('should parse only an elementStart tag', () {
+    expect(new NgSimpleScanner("<div></div>").scan(),
+        new NgSimpleToken.elementStart(0));
+  });
+
+  test('should parse end of file', () {
+    expect(new NgSimpleScanner("").scan(), new NgSimpleToken.EOF(0));
+  });
+}


### PR DESCRIPTION
Groundwork for discussed simpler tokenizer that is agnostic of current html/angular state as discussed in 'Simpler Lexer Proposal'. It has minimal states just for better tokenizing results, but none that determines the validity of an html tag, comment, or text.

This can be easily merged into the existing scanner implementation by parsing through tokens instead of raw string. The existing scanner can be kept as a fail-fast version. A different version can be implemented that will not fail-fast but attempt to recover and inject synthetic nodes while also reporting errors. 