### PR TITLE
Ast recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .packages
 .pub
 pubspec.lock
+test/random_generator_test/incorrect.html
+test/random_generator_test/lexer_fixed.html
+test/random_generator_test/ast_fixed.html

--- a/lib/angular_ast.dart
+++ b/lib/angular_ast.dart
@@ -34,6 +34,8 @@ export 'package:angular_ast/src/ast.dart'
         TemplateAst,
         TextAst,
         WhitespaceAst;
+export 'package:angular_ast/src/exception_handler/exception_handler.dart'
+    show ExceptionHandler, RecoveringExceptionHandler, ThrowingExceptionHandler;
 export 'package:angular_ast/src/lexer.dart' show NgLexer;
 export 'package:angular_ast/src/parser.dart' show NgParser;
 export 'package:angular_ast/src/token/tokens.dart'

--- a/lib/angular_ast.dart
+++ b/lib/angular_ast.dart
@@ -10,6 +10,7 @@ export 'package:angular_ast/src/ast.dart'
     show
         AttributeAst,
         BananaAst,
+        CloseElementAst,
         CommentAst,
         ElementAst,
         EmbeddedContentAst,
@@ -19,6 +20,7 @@ export 'package:angular_ast/src/ast.dart'
         InterpolationAst,
         ParsedAttributeAst,
         ParsedBananaAst,
+        ParsedCloseElementAst,
         ParsedEventAst,
         ParsedElementAst,
         ParsedPropertyAst,

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -4,6 +4,8 @@
 
 export 'package:angular_ast/src/ast/attribute.dart'
     show AttributeAst, ParsedAttributeAst;
+export 'package:angular_ast/src/ast/close_element.dart'
+    show CloseElementAst, ParsedCloseElementAst;
 export 'package:angular_ast/src/ast/comment.dart' show CommentAst;
 export 'package:angular_ast/src/ast/content.dart' show EmbeddedContentAst;
 export 'package:angular_ast/src/ast/element.dart'

--- a/lib/src/ast/close_element.dart
+++ b/lib/src/ast/close_element.dart
@@ -1,0 +1,139 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:angular_ast/src/ast.dart';
+import 'package:angular_ast/src/token/tokens.dart';
+import 'package:angular_ast/src/visitor.dart';
+import 'package:source_span/source_span.dart';
+import 'package:quiver/core.dart';
+
+/// Represents the closing DOM element that was parsed.
+///
+/// Clients should not extend, implement, or mix-in this class.
+abstract class CloseElementAst implements StandaloneTemplateAst {
+  /// Creates a synthetic close element AST.
+  factory CloseElementAst(
+    String name, {
+    ElementAst openComplement,
+    List<WhitespaceAst> whitespaces,
+  }) = _SyntheticCloseElementAst;
+
+  /// Creates a synthetic close element AST from an existing AST node.
+  factory CloseElementAst.from(
+    TemplateAst origin,
+    String name, {
+    ElementAst openComplement,
+    List<WhitespaceAst> whitespaces,
+  }) = _SyntheticCloseElementAst.from;
+
+  /// Creates a new close element AST from a parsed source
+  factory CloseElementAst.parsed(
+    SourceFile sourceFile,
+    NgToken closeTagStart,
+    NgToken nameToken,
+    NgToken closeTagEnd, {
+    ElementAst openComplement,
+    List<WhitespaceAst> whitespaces,
+  }) = ParsedCloseElementAst;
+
+  @override
+  bool operator ==(Object o) {
+    if (o is CloseElementAst) {
+      return name == o.name && openComplement == o.openComplement;
+    }
+    return false;
+  }
+
+  @override
+  int get hashCode => hash2(name, openComplement);
+
+  @override
+  /*=R*/ accept/*<R, C>*/(TemplateAstVisitor/*<R, C>*/ visitor, [C context]) {
+    return visitor.visitCloseElement(this, context);
+  }
+
+  /// Whether this is a `</template>` tag and should be directly rendered.
+  bool get isEmbeddedTemplate => name == 'template';
+
+  /// Name (tag) of the close element.
+  String get name;
+
+  /// [ElementAst] that represents the open complement.
+  ElementAst get openComplement;
+
+  /// Whitespaces at the end
+  List<WhitespaceAst> get whitespaces;
+
+  @override
+  String toString() {
+    final buffer = new StringBuffer('$CloseElementAst <$name> { ');
+    if (openComplement != null) {
+      buffer..write('openComplement=')..write(openComplement)..write(' ');
+    }
+    if (whitespaces.isNotEmpty) {
+      buffer
+        ..write('whitespaces=')
+        ..writeAll(whitespaces, ', ')
+        ..write(' ');
+    }
+    return (buffer..write('}')).toString();
+  }
+}
+
+/// Represents a real, non-synthetic DOM close element that was parsed,
+/// that could be upgraded.abstract
+///
+/// Clients should not extned, implement, or mix-in this class.
+class ParsedCloseElementAst extends TemplateAst with CloseElementAst {
+  /// [NgToken] that represents the identifier tag in `</tag>`.
+  final NgToken identifierToken;
+
+  ParsedCloseElementAst(
+    SourceFile sourceFile,
+    NgToken closeElementStart,
+    this.identifierToken,
+    NgToken closeElementEnd, {
+    ElementAst openComplement,
+    this.whitespaces: const [],
+  })
+      : openComplement = openComplement,
+        super.parsed(closeElementStart, closeElementEnd, sourceFile);
+
+  @override
+  String get name => identifierToken.lexeme;
+
+  /// Complement open element ast
+  @override
+  ElementAst openComplement;
+
+  /// Whitespaces
+  @override
+  final List<WhitespaceAst> whitespaces;
+}
+
+class _SyntheticCloseElementAst extends SyntheticTemplateAst
+    with CloseElementAst {
+  _SyntheticCloseElementAst(
+    this.name, {
+    this.openComplement,
+    this.whitespaces: const [],
+  });
+
+  _SyntheticCloseElementAst.from(
+    TemplateAst origin,
+    this.name, {
+    this.openComplement,
+    this.whitespaces: const [],
+  })
+      : super.from(origin);
+
+  @override
+  final String name;
+
+  @override
+  ElementAst openComplement;
+
+  @override
+  final List<WhitespaceAst> whitespaces;
+}

--- a/lib/src/ast/close_element.dart
+++ b/lib/src/ast/close_element.dart
@@ -6,7 +6,6 @@ import 'package:angular_ast/src/ast.dart';
 import 'package:angular_ast/src/token/tokens.dart';
 import 'package:angular_ast/src/visitor.dart';
 import 'package:source_span/source_span.dart';
-import 'package:quiver/core.dart';
 
 /// Represents the closing DOM element that was parsed.
 ///
@@ -15,7 +14,6 @@ abstract class CloseElementAst implements StandaloneTemplateAst {
   /// Creates a synthetic close element AST.
   factory CloseElementAst(
     String name, {
-    ElementAst openComplement,
     List<WhitespaceAst> whitespaces,
   }) = _SyntheticCloseElementAst;
 
@@ -23,7 +21,6 @@ abstract class CloseElementAst implements StandaloneTemplateAst {
   factory CloseElementAst.from(
     TemplateAst origin,
     String name, {
-    ElementAst openComplement,
     List<WhitespaceAst> whitespaces,
   }) = _SyntheticCloseElementAst.from;
 
@@ -40,13 +37,13 @@ abstract class CloseElementAst implements StandaloneTemplateAst {
   @override
   bool operator ==(Object o) {
     if (o is CloseElementAst) {
-      return name == o.name && openComplement == o.openComplement;
+      return name == o.name;
     }
     return false;
   }
 
   @override
-  int get hashCode => hash2(name, openComplement);
+  int get hashCode => name.hashCode;
 
   @override
   /*=R*/ accept/*<R, C>*/(TemplateAstVisitor/*<R, C>*/ visitor, [C context]) {
@@ -59,18 +56,12 @@ abstract class CloseElementAst implements StandaloneTemplateAst {
   /// Name (tag) of the close element.
   String get name;
 
-  /// [ElementAst] that represents the open complement.
-  ElementAst get openComplement;
-
   /// Whitespaces at the end
   List<WhitespaceAst> get whitespaces;
 
   @override
   String toString() {
     final buffer = new StringBuffer('$CloseElementAst <$name> { ');
-    if (openComplement != null) {
-      buffer..write('openComplement=')..write(openComplement)..write(' ');
-    }
     if (whitespaces.isNotEmpty) {
       buffer
         ..write('whitespaces=')
@@ -97,15 +88,10 @@ class ParsedCloseElementAst extends TemplateAst with CloseElementAst {
     ElementAst openComplement,
     this.whitespaces: const [],
   })
-      : openComplement = openComplement,
-        super.parsed(closeElementStart, closeElementEnd, sourceFile);
+      : super.parsed(closeElementStart, closeElementEnd, sourceFile);
 
   @override
   String get name => identifierToken.lexeme;
-
-  /// Complement open element ast
-  @override
-  ElementAst openComplement;
 
   /// Whitespaces
   @override
@@ -116,23 +102,18 @@ class _SyntheticCloseElementAst extends SyntheticTemplateAst
     with CloseElementAst {
   _SyntheticCloseElementAst(
     this.name, {
-    this.openComplement,
     this.whitespaces: const [],
   });
 
   _SyntheticCloseElementAst.from(
     TemplateAst origin,
     this.name, {
-    this.openComplement,
     this.whitespaces: const [],
   })
       : super.from(origin);
 
   @override
   final String name;
-
-  @override
-  ElementAst openComplement;
 
   @override
   final List<WhitespaceAst> whitespaces;

--- a/lib/src/ast/close_element.dart
+++ b/lib/src/ast/close_element.dart
@@ -61,7 +61,7 @@ abstract class CloseElementAst implements TemplateAst {
 
   @override
   String toString() {
-    final buffer = new StringBuffer('$CloseElementAst <$name> { ');
+    final buffer = new StringBuffer('$CloseElementAst </$name> { ');
     if (whitespaces.isNotEmpty) {
       buffer
         ..write('whitespaces=')
@@ -72,10 +72,9 @@ abstract class CloseElementAst implements TemplateAst {
   }
 }
 
-/// Represents a real, non-synthetic DOM close element that was parsed,
-/// that could be upgraded.abstract
+/// Represents a real, non-synthetic DOM close element that was parsed.
 ///
-/// Clients should not extned, implement, or mix-in this class.
+/// Clients should not extend, implement, or mix-in this class.
 class ParsedCloseElementAst extends TemplateAst with CloseElementAst {
   /// [NgToken] that represents the identifier tag in `</tag>`.
   final NgToken identifierToken;

--- a/lib/src/ast/close_element.dart
+++ b/lib/src/ast/close_element.dart
@@ -10,7 +10,7 @@ import 'package:source_span/source_span.dart';
 /// Represents the closing DOM element that was parsed.
 ///
 /// Clients should not extend, implement, or mix-in this class.
-abstract class CloseElementAst implements StandaloneTemplateAst {
+abstract class CloseElementAst implements TemplateAst {
   /// Creates a synthetic close element AST.
   factory CloseElementAst(
     String name, {

--- a/lib/src/ast/close_element.dart
+++ b/lib/src/ast/close_element.dart
@@ -55,6 +55,9 @@ abstract class CloseElementAst implements TemplateAst {
   /// Name (tag) of the close element.
   String get name;
 
+  //TODO: Max: remove entirely
+  @deprecated
+
   /// Whitespaces at the end.
   List<WhitespaceAst> get whitespaces;
 

--- a/lib/src/ast/close_element.dart
+++ b/lib/src/ast/close_element.dart
@@ -24,7 +24,7 @@ abstract class CloseElementAst implements TemplateAst {
     List<WhitespaceAst> whitespaces,
   }) = _SyntheticCloseElementAst.from;
 
-  /// Creates a new close element AST from a parsed source
+  /// Creates a new close element AST from a parsed source.
   factory CloseElementAst.parsed(
     SourceFile sourceFile,
     NgToken closeTagStart,
@@ -46,9 +46,8 @@ abstract class CloseElementAst implements TemplateAst {
   int get hashCode => name.hashCode;
 
   @override
-  /*=R*/ accept/*<R, C>*/(TemplateAstVisitor/*<R, C>*/ visitor, [C context]) {
-    return visitor.visitCloseElement(this, context);
-  }
+  /*=R*/ accept/*<R, C>*/(TemplateAstVisitor/*<R, C>*/ visitor, [C context]) =>
+      visitor.visitCloseElement(this, context);
 
   /// Whether this is a `</template>` tag and should be directly rendered.
   bool get isEmbeddedTemplate => name == 'template';
@@ -56,12 +55,12 @@ abstract class CloseElementAst implements TemplateAst {
   /// Name (tag) of the close element.
   String get name;
 
-  /// Whitespaces at the end
+  /// Whitespaces at the end.
   List<WhitespaceAst> get whitespaces;
 
   @override
   String toString() {
-    final buffer = new StringBuffer('$CloseElementAst </$name> { ');
+    var buffer = new StringBuffer('$CloseElementAst </$name> { ');
     if (whitespaces.isNotEmpty) {
       buffer
         ..write('whitespaces=')

--- a/lib/src/ast/element.dart
+++ b/lib/src/ast/element.dart
@@ -19,7 +19,6 @@ abstract class ElementAst implements StandaloneTemplateAst {
   factory ElementAst(
     String name, {
     bool isVoidElement,
-    bool usesVoidTagEnd,
     CloseElementAst closeComplement,
     List<AttributeAst> attributes,
     List<StandaloneTemplateAst> childNodes,
@@ -36,7 +35,6 @@ abstract class ElementAst implements StandaloneTemplateAst {
     TemplateAst origin,
     String name, {
     bool isVoidElement,
-    bool usesVoidTagEnd,
     CloseElementAst closeComplement,
     List<AttributeAst> attributes,
     List<StandaloneTemplateAst> childNodes,
@@ -72,7 +70,6 @@ abstract class ElementAst implements StandaloneTemplateAst {
       return name == o.name &&
           closeComplement == o.closeComplement &&
           isVoidElement == o.isVoidElement &&
-          usesVoidTagEnd == o.usesVoidTagEnd &&
           _listEquals.equals(attributes, o.attributes) &&
           _listEquals.equals(childNodes, o.childNodes) &&
           _listEquals.equals(events, o.events) &&
@@ -90,7 +87,6 @@ abstract class ElementAst implements StandaloneTemplateAst {
       name,
       closeComplement,
       isVoidElement,
-      usesVoidTagEnd,
       _listEquals.hash(attributes),
       _listEquals.hash(childNodes),
       _listEquals.hash(events),
@@ -111,11 +107,6 @@ abstract class ElementAst implements StandaloneTemplateAst {
 
   /// Determines whether the element tag name is void element.
   bool get isVoidElement;
-
-  /// Whether this uses the void tag end '/>'.
-  ///
-  /// By definition, a void element can use either '>' or '/>'.
-  bool get usesVoidTagEnd;
 
   /// CloseElement complement
   ///
@@ -143,6 +134,9 @@ abstract class ElementAst implements StandaloneTemplateAst {
 
   /// Star assignments.
   List<StarAst> get stars;
+
+  //TODO: Max: remove entirely
+  @deprecated
 
   /// Whitespaces
   List<WhitespaceAst> get whitespaces;
@@ -217,9 +211,6 @@ class ParsedElementAst extends TemplateAst with ElementAst {
   @override
   final bool isVoidElement;
 
-  @override
-  final bool usesVoidTagEnd;
-
   ParsedElementAst(
     SourceFile sourceFile,
     NgToken openElementStart,
@@ -236,8 +227,7 @@ class ParsedElementAst extends TemplateAst with ElementAst {
     this.stars: const [],
     this.whitespaces: const [],
   })
-      : usesVoidTagEnd = openElementEnd.type == NgTokenType.openElementEndVoid,
-        super.parsed(openElementStart, openElementEnd, sourceFile);
+      : super.parsed(openElementStart, openElementEnd, sourceFile);
 
   /// Name (tag) of the element.
   @override
@@ -284,7 +274,6 @@ class _SyntheticElementAst extends SyntheticTemplateAst with ElementAst {
   _SyntheticElementAst(
     this.name, {
     this.isVoidElement: false,
-    this.usesVoidTagEnd: false,
     this.closeComplement,
     this.attributes: const [],
     this.childNodes: const [],
@@ -304,7 +293,6 @@ class _SyntheticElementAst extends SyntheticTemplateAst with ElementAst {
     TemplateAst origin,
     this.name, {
     this.isVoidElement: false,
-    this.usesVoidTagEnd: false,
     this.closeComplement,
     this.attributes: const [],
     this.childNodes: const [],
@@ -329,9 +317,6 @@ class _SyntheticElementAst extends SyntheticTemplateAst with ElementAst {
 
   @override
   final bool isVoidElement;
-
-  @override
-  final bool usesVoidTagEnd;
 
   @override
   final List<AttributeAst> attributes;

--- a/lib/src/ast/element.dart
+++ b/lib/src/ast/element.dart
@@ -17,9 +17,8 @@ const _listEquals = const ListEquality();
 abstract class ElementAst implements StandaloneTemplateAst {
   /// Create a synthetic element AST.
   factory ElementAst(
-    String name, {
-    bool isVoidElement,
-    CloseElementAst closeComplement,
+    String name,
+    CloseElementAst closeComplement, {
     List<AttributeAst> attributes,
     List<StandaloneTemplateAst> childNodes,
     List<EventAst> events,
@@ -33,9 +32,8 @@ abstract class ElementAst implements StandaloneTemplateAst {
   /// Create a synthetic element AST from an existing AST node.
   factory ElementAst.from(
     TemplateAst origin,
-    String name, {
-    bool isVoidElement,
-    CloseElementAst closeComplement,
+    String name,
+    CloseElementAst closeComplement, {
     List<AttributeAst> attributes,
     List<StandaloneTemplateAst> childNodes,
     List<EventAst> events,
@@ -52,7 +50,6 @@ abstract class ElementAst implements StandaloneTemplateAst {
     NgToken openElementStart,
     NgToken nameToken,
     NgToken openElementEnd, {
-    bool isVoidElement,
     CloseElementAst closeComplement,
     List<AttributeAst> attributes,
     List<StandaloneTemplateAst> childNodes,
@@ -69,7 +66,6 @@ abstract class ElementAst implements StandaloneTemplateAst {
     if (o is ElementAst) {
       return name == o.name &&
           closeComplement == o.closeComplement &&
-          isVoidElement == o.isVoidElement &&
           _listEquals.equals(attributes, o.attributes) &&
           _listEquals.equals(childNodes, o.childNodes) &&
           _listEquals.equals(events, o.events) &&
@@ -86,7 +82,6 @@ abstract class ElementAst implements StandaloneTemplateAst {
     return hashObjects([
       name,
       closeComplement,
-      isVoidElement,
       _listEquals.hash(attributes),
       _listEquals.hash(childNodes),
       _listEquals.hash(events),
@@ -110,7 +105,7 @@ abstract class ElementAst implements StandaloneTemplateAst {
 
   /// CloseElement complement
   ///
-  /// If [isVoidElement] is `true`, closeComplement must be null.
+  /// If [closeComplement] == null, then [isVoidElement] is true.
   CloseElementAst get closeComplement;
   set closeComplement(CloseElementAst closeElementAst);
 
@@ -207,16 +202,11 @@ class ParsedElementAst extends TemplateAst with ElementAst {
   /// [NgToken] that represents the identifier tag in `<tag ...>`.
   final NgToken identifierToken;
 
-  /// Indicates that the element identifier is a void element.
-  @override
-  final bool isVoidElement;
-
   ParsedElementAst(
     SourceFile sourceFile,
     NgToken openElementStart,
     this.identifierToken,
     NgToken openElementEnd, {
-    this.isVoidElement: false,
     this.closeComplement,
     this.attributes: const [],
     this.childNodes: const [],
@@ -236,6 +226,9 @@ class ParsedElementAst extends TemplateAst with ElementAst {
   /// CloseElementAst that complements this elementAst.
   @override
   CloseElementAst closeComplement;
+
+  @override
+  bool get isVoidElement => closeComplement == null;
 
   /// Attributes
   @override
@@ -272,9 +265,8 @@ class ParsedElementAst extends TemplateAst with ElementAst {
 
 class _SyntheticElementAst extends SyntheticTemplateAst with ElementAst {
   _SyntheticElementAst(
-    this.name, {
-    this.isVoidElement: false,
-    this.closeComplement,
+    this.name,
+    this.closeComplement, {
     this.attributes: const [],
     this.childNodes: const [],
     this.events: const [],
@@ -283,17 +275,12 @@ class _SyntheticElementAst extends SyntheticTemplateAst with ElementAst {
     this.bananas: const [],
     this.stars: const [],
     this.whitespaces: const [],
-  }) {
-    if (this.closeComplement == null && !isVoidElement) {
-      this.closeComplement = new CloseElementAst(name);
-    }
-  }
+  });
 
   _SyntheticElementAst.from(
     TemplateAst origin,
-    this.name, {
-    this.isVoidElement: false,
-    this.closeComplement,
+    this.name,
+    this.closeComplement, {
     this.attributes: const [],
     this.childNodes: const [],
     this.events: const [],
@@ -303,11 +290,7 @@ class _SyntheticElementAst extends SyntheticTemplateAst with ElementAst {
     this.stars: const [],
     this.whitespaces: const [],
   })
-      : super.from(origin) {
-    if (this.closeComplement == null && !isVoidElement) {
-      this.closeComplement = new CloseElementAst(name);
-    }
-  }
+      : super.from(origin);
 
   @override
   final String name;
@@ -316,7 +299,7 @@ class _SyntheticElementAst extends SyntheticTemplateAst with ElementAst {
   CloseElementAst closeComplement;
 
   @override
-  final bool isVoidElement;
+  bool get isVoidElement => closeComplement == null;
 
   @override
   final List<AttributeAst> attributes;

--- a/lib/src/ast/element.dart
+++ b/lib/src/ast/element.dart
@@ -121,6 +121,7 @@ abstract class ElementAst implements StandaloneTemplateAst {
   ///
   /// If [isVoidElement] is `true`, closeComplement must be null.
   CloseElementAst get closeComplement;
+  set closeComplement(CloseElementAst closeElementAst);
 
   /// Name (tag) of the element.
   String get name;

--- a/lib/src/ast/event.dart
+++ b/lib/src/ast/event.dart
@@ -16,6 +16,7 @@ abstract class EventAst implements TemplateAst {
   /// Create a new synthetic [EventAst] listening to [name].
   factory EventAst(
     String name,
+    String value,
     ExpressionAst expression, [
     String postfix,
   ]) = _SyntheticEventAst;
@@ -24,6 +25,7 @@ abstract class EventAst implements TemplateAst {
   factory EventAst.from(
     TemplateAst origin,
     String name,
+    String value,
     ExpressionAst expression, [
     String postfix,
   ]) = _SyntheticEventAst.from;
@@ -36,6 +38,7 @@ abstract class EventAst implements TemplateAst {
     NgToken elementDecoratorToken,
     NgToken suffixToken,
     NgAttributeValueToken valueToken,
+    ExpressionAst expression,
     NgToken equalSignToken,
   ) = ParsedEventAst;
 
@@ -59,6 +62,9 @@ abstract class EventAst implements TemplateAst {
 
   /// Name of the event being listened to.
   String get name;
+
+  /// Unquoted value being bound to event.
+  String get value;
 
   /// An optional postfix used to filter events that support it.
   ///
@@ -100,13 +106,10 @@ class ParsedEventAst extends TemplateAst
     this.nameToken,
     this.suffixToken,
     this.valueToken,
+    this.expression,
     this.equalSignToken,
   )
-      : this.expression = valueToken != null
-            ? new ExpressionAst.parse(valueToken.innerValue.lexeme,
-                sourceUrl: sourceFile.url.toString())
-            : null,
-        super.parsed(
+      : super.parsed(
           beginToken,
           valueToken == null ? suffixToken : valueToken.rightQuote,
           sourceFile,
@@ -133,6 +136,7 @@ class ParsedEventAst extends TemplateAst
   int get equalSignOffset => equalSignToken.offset;
 
   /// Expression value as [String] bound to event; may be `null` if no value.
+  @override
   String get value => valueToken?.innerValue?.lexeme;
 
   /// Offset of value; may be `null` to have no value.
@@ -164,16 +168,25 @@ class _SyntheticEventAst extends SyntheticTemplateAst with EventAst {
   final String name;
 
   @override
+  final String value;
+
+  @override
   final ExpressionAst expression;
 
   @override
   final String postfix;
 
-  _SyntheticEventAst(this.name, this.expression, [this.postfix]);
+  _SyntheticEventAst(
+    this.name,
+    this.value,
+    this.expression, [
+    this.postfix,
+  ]);
 
   _SyntheticEventAst.from(
     TemplateAst origin,
     this.name,
+    this.value,
     this.expression, [
     this.postfix,
   ])

--- a/lib/src/ast/expression.dart
+++ b/lib/src/ast/expression.dart
@@ -23,21 +23,11 @@ class ExpressionAst implements TemplateAst {
     @required String sourceUrl,
     ExceptionHandler exceptionHandler,
   }) {
-    // TODO: REMOVE exceptionHandling LATER
-    ExpressionAst expressionAst;
-    if (exceptionHandler == null) {
-      exceptionHandler = new RecoveringExceptionHandler();
-    }
-    try {
-      expressionAst = new ExpressionAst(parseExpression(
+      return new ExpressionAst(parseExpression(
         expression,
         deSugarPipes: deSugarPipes,
         sourceUrl: sourceUrl,
       ));
-    } catch (e) {
-      exceptionHandler.handle(e);
-    }
-    return expressionAst;
   }
 
   @override

--- a/lib/src/ast/expression.dart
+++ b/lib/src/ast/expression.dart
@@ -21,12 +21,23 @@ class ExpressionAst implements TemplateAst {
     String expression, {
     bool deSugarPipes: true,
     @required String sourceUrl,
+    ExceptionHandler exceptionHandler,
   }) {
-    return new ExpressionAst(parseExpression(
-      expression,
-      deSugarPipes: deSugarPipes,
-      sourceUrl: sourceUrl,
-    ));
+    // TODO: REMOVE exceptionHandling LATER
+    ExpressionAst expressionAst;
+    if (exceptionHandler == null) {
+      exceptionHandler = new RecoveringExceptionHandler();
+    }
+    try {
+      expressionAst = new ExpressionAst(parseExpression(
+        expression,
+        deSugarPipes: deSugarPipes,
+        sourceUrl: sourceUrl,
+      ));
+    } catch (e) {
+      exceptionHandler.handle(e);
+    }
+    return expressionAst;
   }
 
   @override

--- a/lib/src/ast/expression.dart
+++ b/lib/src/ast/expression.dart
@@ -23,11 +23,11 @@ class ExpressionAst implements TemplateAst {
     @required String sourceUrl,
     ExceptionHandler exceptionHandler,
   }) {
-      return new ExpressionAst(parseExpression(
-        expression,
-        deSugarPipes: deSugarPipes,
-        sourceUrl: sourceUrl,
-      ));
+    return new ExpressionAst(parseExpression(
+      expression,
+      deSugarPipes: deSugarPipes,
+      sourceUrl: sourceUrl,
+    ));
   }
 
   @override

--- a/lib/src/ast/interpolation.dart
+++ b/lib/src/ast/interpolation.dart
@@ -26,6 +26,7 @@ abstract class InterpolationAst implements StandaloneTemplateAst {
     SourceFile sourceFile,
     NgToken beginToken,
     String value,
+    ExpressionAst expression,
     NgToken endToken,
   ) = _ParsedInterpolationAst;
 
@@ -63,13 +64,10 @@ class _ParsedInterpolationAst extends TemplateAst with InterpolationAst {
     SourceFile sourceFile,
     NgToken beginToken,
     this.value,
+    this.expression,
     NgToken endToken,
   )
-      : expression = new ExpressionAst.parse(
-          value,
-          sourceUrl: sourceFile.url.toString(),
-        ),
-        super.parsed(beginToken, endToken, sourceFile);
+      : super.parsed(beginToken, endToken, sourceFile);
 }
 
 class _SyntheticInterpolationAst extends SyntheticTemplateAst

--- a/lib/src/ast/property.dart
+++ b/lib/src/ast/property.dart
@@ -16,6 +16,7 @@ abstract class PropertyAst implements TemplateAst {
   /// Create a new synthetic [PropertyAst] assigned to [name].
   factory PropertyAst(
     String name, [
+    String value,
     ExpressionAst expression,
     String postfix,
     String unit,
@@ -25,6 +26,7 @@ abstract class PropertyAst implements TemplateAst {
   factory PropertyAst.from(
     TemplateAst origin,
     String name, [
+    String value,
     ExpressionAst expression,
     String postfix,
     String unit,
@@ -38,6 +40,7 @@ abstract class PropertyAst implements TemplateAst {
     NgToken elementDecoratorToken,
     NgToken suffixToken, [
     NgAttributeValueToken valueToken,
+    ExpressionAst expressionAst,
     NgToken equalSignToken,
   ]) = ParsedPropertyAst;
 
@@ -65,6 +68,9 @@ abstract class PropertyAst implements TemplateAst {
 
   /// Name of the property being set.
   String get name;
+
+  /// Unquoted value being bound to property
+  String get value;
 
   /// An optional indicator for some properties as a shorthand syntax.
   ///
@@ -127,13 +133,10 @@ class ParsedPropertyAst extends TemplateAst
     this.nameToken,
     this.suffixToken, [
     this.valueToken,
+    this.expression,
     this.equalSignToken,
   ])
-      : this.expression = valueToken != null
-            ? new ExpressionAst.parse(valueToken.innerValue.lexeme,
-                sourceUrl: sourceFile.url.toString())
-            : null,
-        super.parsed(
+      : super.parsed(
             beginToken,
             valueToken == null ? suffixToken : valueToken.rightQuote,
             sourceFile);
@@ -157,6 +160,7 @@ class ParsedPropertyAst extends TemplateAst
   int get equalSignOffset => equalSignToken?.offset;
 
   /// Expression value as [String] bound to property; may be `null` if no value.
+  @override
   String get value => valueToken?.innerValue?.lexeme;
 
   /// Offset of value; may be `null` to have no value.
@@ -193,6 +197,7 @@ class ParsedPropertyAst extends TemplateAst
 class _SyntheticPropertyAst extends SyntheticTemplateAst with PropertyAst {
   _SyntheticPropertyAst(
     this.name, [
+    this.value,
     this.expression,
     this.postfix,
     this.unit,
@@ -201,6 +206,7 @@ class _SyntheticPropertyAst extends SyntheticTemplateAst with PropertyAst {
   _SyntheticPropertyAst.from(
     TemplateAst origin,
     this.name, [
+    this.value,
     this.expression,
     this.postfix,
     this.unit,
@@ -212,6 +218,9 @@ class _SyntheticPropertyAst extends SyntheticTemplateAst with PropertyAst {
 
   @override
   final String name;
+
+  @override
+  final String value;
 
   @override
   final String postfix;

--- a/lib/src/ast/property.dart
+++ b/lib/src/ast/property.dart
@@ -69,7 +69,7 @@ abstract class PropertyAst implements TemplateAst {
   /// Name of the property being set.
   String get name;
 
-  /// Unquoted value being bound to property
+  /// Unquoted value being bound to property.
   String get value;
 
   /// An optional indicator for some properties as a shorthand syntax.

--- a/lib/src/ast/sugar/banana.dart
+++ b/lib/src/ast/sugar/banana.dart
@@ -36,6 +36,8 @@ abstract class BananaAst implements TemplateAst {
     NgToken elementDecoratorToken,
     NgToken suffixToken,
     NgAttributeValueToken valueToken,
+    ExpressionAst eventExpression,
+    ExpressionAst propertyExpression,
     NgToken equalSignToken,
   ) = ParsedBananaAst;
 
@@ -47,7 +49,10 @@ abstract class BananaAst implements TemplateAst {
   @override
   bool operator ==(Object o) {
     if (o is BananaAst) {
-      return name == o.name && value == o.value;
+      return name == o.name &&
+          value == o.value &&
+          eventExpression == o.eventExpression &&
+          propertyExpression == o.propertyExpression;
     }
     return false;
   }
@@ -60,6 +65,12 @@ abstract class BananaAst implements TemplateAst {
 
   /// Value bound to.
   String get value;
+
+  /// Expression to be bound to event after desugaring.
+  ExpressionAst get eventExpression;
+
+  /// Expression to be bound to property after desugaring.
+  ExpressionAst get propertyExpression;
 
   @override
   String toString() {
@@ -80,6 +91,12 @@ class ParsedBananaAst extends TemplateAst
   final NgToken nameToken;
   final NgToken suffixToken;
 
+  @override
+  final ExpressionAst eventExpression;
+
+  @override
+  final ExpressionAst propertyExpression;
+
   /// [NgAttributeValueToken] that represents `"value"`; may be `null` to have
   /// no value.
   final NgAttributeValueToken valueToken;
@@ -95,6 +112,8 @@ class ParsedBananaAst extends TemplateAst
     this.nameToken,
     this.suffixToken,
     this.valueToken,
+    this.eventExpression,
+    this.propertyExpression,
     this.equalSignToken,
   )
       : super.parsed(
@@ -142,12 +161,21 @@ class _SyntheticBananaAst extends SyntheticTemplateAst with BananaAst {
   @override
   final String value;
 
-  _SyntheticBananaAst(this.name, [this.value]);
+  @override
+  final ExpressionAst eventExpression;
+
+  @override
+  final ExpressionAst propertyExpression;
+
+  _SyntheticBananaAst(this.name,
+      [this.value, this.eventExpression, this.propertyExpression]);
 
   _SyntheticBananaAst.from(
     TemplateAst origin,
     this.name, [
     this.value,
+    this.eventExpression,
+    this.propertyExpression,
   ])
       : super.from(origin);
 }

--- a/lib/src/ast/sugar/banana.dart
+++ b/lib/src/ast/sugar/banana.dart
@@ -99,7 +99,7 @@ class ParsedBananaAst extends TemplateAst
   )
       : super.parsed(
             beginToken,
-            (valueToken == null ? valueToken.rightQuote : suffixToken),
+            (valueToken != null ? valueToken.rightQuote : suffixToken),
             sourceFile);
 
   /// Inner name `property` in `[(property)]`.

--- a/lib/src/ast/sugar/banana.dart
+++ b/lib/src/ast/sugar/banana.dart
@@ -36,8 +36,6 @@ abstract class BananaAst implements TemplateAst {
     NgToken elementDecoratorToken,
     NgToken suffixToken,
     NgAttributeValueToken valueToken,
-    ExpressionAst eventExpression,
-    ExpressionAst propertyExpression,
     NgToken equalSignToken,
   ) = ParsedBananaAst;
 
@@ -49,10 +47,7 @@ abstract class BananaAst implements TemplateAst {
   @override
   bool operator ==(Object o) {
     if (o is BananaAst) {
-      return name == o.name &&
-          value == o.value &&
-          eventExpression == o.eventExpression &&
-          propertyExpression == o.propertyExpression;
+      return name == o.name && value == o.value;
     }
     return false;
   }
@@ -65,12 +60,6 @@ abstract class BananaAst implements TemplateAst {
 
   /// Value bound to.
   String get value;
-
-  /// Expression to be bound to event after desugaring.
-  ExpressionAst get eventExpression;
-
-  /// Expression to be bound to property after desugaring.
-  ExpressionAst get propertyExpression;
 
   @override
   String toString() {
@@ -91,12 +80,6 @@ class ParsedBananaAst extends TemplateAst
   final NgToken nameToken;
   final NgToken suffixToken;
 
-  @override
-  final ExpressionAst eventExpression;
-
-  @override
-  final ExpressionAst propertyExpression;
-
   /// [NgAttributeValueToken] that represents `"value"`; may be `null` to have
   /// no value.
   final NgAttributeValueToken valueToken;
@@ -112,8 +95,6 @@ class ParsedBananaAst extends TemplateAst
     this.nameToken,
     this.suffixToken,
     this.valueToken,
-    this.eventExpression,
-    this.propertyExpression,
     this.equalSignToken,
   )
       : super.parsed(
@@ -161,21 +142,12 @@ class _SyntheticBananaAst extends SyntheticTemplateAst with BananaAst {
   @override
   final String value;
 
-  @override
-  final ExpressionAst eventExpression;
-
-  @override
-  final ExpressionAst propertyExpression;
-
-  _SyntheticBananaAst(this.name,
-      [this.value, this.eventExpression, this.propertyExpression]);
+  _SyntheticBananaAst(this.name, [this.value]);
 
   _SyntheticBananaAst.from(
     TemplateAst origin,
     this.name, [
     this.value,
-    this.eventExpression,
-    this.propertyExpression,
   ])
       : super.from(origin);
 }

--- a/lib/src/ast/sugar/star.dart
+++ b/lib/src/ast/sugar/star.dart
@@ -18,14 +18,14 @@ abstract class StarAst implements TemplateAst {
   /// Create a new synthetic [StarAst] assigned to [name].
   factory StarAst(
     String name, [
-    ExpressionAst expression,
+    String value,
   ]) = _SyntheticStarAst;
 
   /// Create a new synthetic property AST that originated from another AST.
   factory StarAst.from(
     TemplateAst origin,
     String name, [
-    ExpressionAst expression,
+    String value,
   ]) = _SyntheticStarAst.from;
 
   /// Create a new property assignment parsed from tokens in [sourceFile].
@@ -46,27 +46,24 @@ abstract class StarAst implements TemplateAst {
   @override
   bool operator ==(Object o) {
     if (o is PropertyAst) {
-      return expression == o.expression && name == o.name;
+      return value == o.value && name == o.name;
     }
     return false;
   }
 
   @override
-  int get hashCode => hash2(expression, name);
-
-  /// Bound expression; optional for backwards compatibility.
-  ExpressionAst get expression;
+  int get hashCode => hash2(value, name);
 
   /// Name of the directive being created.
   String get name;
 
-  /// Name of expression string
+  /// Name of expression string. Can be null.
   String get value;
 
   @override
   String toString() {
-    if (expression != null) {
-      return '$StarAst {$name="$expression"}';
+    if (value != null) {
+      return '$StarAst {$name="$value"}';
     }
     return '$StarAst {$name}';
   }
@@ -99,16 +96,8 @@ class ParsedStarAst extends TemplateAst
     this.valueToken,
     this.equalSignToken,
   ])
-      : this.expression = valueToken != null
-            ? new ExpressionAst.parse(valueToken.innerValue.lexeme,
-                sourceUrl: sourceFile.url.toString())
-            : null,
-        super.parsed(beginToken,
+      : super.parsed(beginToken,
             valueToken != null ? valueToken.rightQuote : nameToken, sourceFile);
-
-  /// ExpressionAst of `"value"`; may be null to have no value.
-  @override
-  final ExpressionAst expression;
 
   /// Name `directive` in `*directive`.
   @override
@@ -146,22 +135,19 @@ class ParsedStarAst extends TemplateAst
 class _SyntheticStarAst extends SyntheticTemplateAst with StarAst {
   _SyntheticStarAst(
     this.name, [
-    this.expression,
+    this.value,
   ]);
 
   _SyntheticStarAst.from(
     TemplateAst origin,
     this.name, [
-    this.expression,
+    this.value,
   ])
       : super.from(origin);
-
-  @override
-  final ExpressionAst expression;
 
   @override
   final String name;
 
   @override
-  String get value => expression.expression.toString();
+  final String value;
 }

--- a/lib/src/expression/micro/parser.dart
+++ b/lib/src/expression/micro/parser.dart
@@ -71,6 +71,7 @@ class _RecursiveMicroAstParser {
     final value = _tokens.current.lexeme;
     properties.add(new PropertyAst(
       '${_directive}${name[0].toUpperCase()}${name.substring(1)}',
+      value,
       new ExpressionAst.parse(
         value,
         sourceUrl: _sourceUrl,
@@ -110,6 +111,7 @@ class _RecursiveMicroAstParser {
       final expression = _tokens.current.lexeme;
       properties.add(new PropertyAst(
         '${_directive}${property[0].toUpperCase()}${property.substring(1)}',
+        expression,
         new ExpressionAst.parse(expression, sourceUrl: _sourceUrl),
       ));
     }

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -31,6 +31,7 @@ class NgParser {
     'source',
     'track',
     'wbr',
+    'path',
   ];
 
   final bool _toolFriendlyAstOrigin;

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -81,6 +81,7 @@ class NgParser {
       ),
       tokens,
       _voidElements,
+      exceptionHandler,
     );
     return parser.parse();
   }

--- a/lib/src/parser/recursive.dart
+++ b/lib/src/parser/recursive.dart
@@ -114,6 +114,13 @@ class RecursiveAstParser {
       NgTokenType prefixType = prefixToken.type;
 
       if (prefixType == NgTokenType.bananaPrefix) {
+        ExpressionAst eventExpression;
+        ExpressionAst propertyExpression;
+        if (valueToken != null) {
+          eventExpression =
+              parseExpression('${valueToken.innerValue?.lexeme} = \$event');
+          propertyExpression = parseExpression(valueToken.innerValue?.lexeme);
+        }
         return new BananaAst.parsed(
           _source,
           beginToken,
@@ -121,9 +128,13 @@ class RecursiveAstParser {
           decoratorToken,
           suffixToken,
           valueToken,
+          eventExpression,
+          propertyExpression,
           equalSignToken,
         );
       } else if (prefixType == NgTokenType.eventPrefix) {
+        ExpressionAst expressionAst =
+            parseExpression(valueToken?.innerValue?.lexeme);
         return new EventAst.parsed(
           _source,
           beginToken,
@@ -131,9 +142,12 @@ class RecursiveAstParser {
           decoratorToken,
           suffixToken,
           valueToken,
+          expressionAst,
           equalSignToken,
         );
       } else if (prefixType == NgTokenType.propertyPrefix) {
+        ExpressionAst expressionAst =
+            parseExpression(valueToken?.innerValue?.lexeme);
         return new PropertyAst.parsed(
           _source,
           beginToken,
@@ -141,6 +155,7 @@ class RecursiveAstParser {
           decoratorToken,
           suffixToken,
           valueToken,
+          expressionAst,
           equalSignToken,
         );
       } else if (prefixType == NgTokenType.referencePrefix) {
@@ -426,4 +441,18 @@ class RecursiveAstParser {
 
   /// Returns and parses a text AST.
   TextAst parseText(NgToken token) => new TextAst.parsed(_source, token);
+
+  /// Parse expression
+  ExpressionAst parseExpression(String expression) {
+    try {
+      if (expression == null) {
+        return null;
+      }
+      return new ExpressionAst.parse(expression,
+          sourceUrl: _source.url.toString());
+    } catch (e) {
+      exceptionHandler.handle(e);
+    }
+    return null;
+  }
 }

--- a/lib/src/parser/recursive.dart
+++ b/lib/src/parser/recursive.dart
@@ -391,10 +391,13 @@ class RecursiveAstParser {
   InterpolationAst parseInterpolation(NgToken beginToken) {
     final valueToken = _reader.expect(NgTokenType.interpolationValue);
     final endToken = _reader.expect(NgTokenType.interpolationEnd);
+    ExpressionAst expressionAst =
+        parseExpression(valueToken?.lexeme);
     return new InterpolationAst.parsed(
       _source,
       beginToken,
       valueToken.lexeme,
+      expressionAst,
       endToken,
     );
   }

--- a/lib/src/parser/recursive.dart
+++ b/lib/src/parser/recursive.dart
@@ -283,7 +283,7 @@ class RecursiveAstParser {
             _source.getText(0),
             closeNameToken.offset,
           ));
-          childNodes.add(parseStandalone(nextToken));
+          childNodes.add(_handleDanglingCloseElement(nextToken));
           closeElementAst = new CloseElementAst(nameToken.lexeme);
         } else {
           closeElementAst = parseCloseElement(nextToken);
@@ -425,14 +425,18 @@ class RecursiveAstParser {
           _source.getText(0),
           token.offset,
         ));
-        CloseElementAst closeElementAst = parseCloseElement(token);
-        ElementAst synthElementAst = new ElementAst(closeElementAst.name);
-        synthElementAst.closeComplement = closeElementAst;
-        return synthElementAst;
+        return _handleDanglingCloseElement(token);
       default:
         _reader.error('Expected standalone token, got ${token.type}');
         return null;
     }
+  }
+
+  StandaloneTemplateAst _handleDanglingCloseElement(NgToken closeStart) {
+    var closeElementAst = parseCloseElement(closeStart);
+    var synthElementAst = new ElementAst(closeElementAst.name);
+    synthElementAst.closeComplement = closeElementAst;
+    return synthElementAst;
   }
 
   /// Returns and parses a text AST.

--- a/lib/src/parser/recursive.dart
+++ b/lib/src/parser/recursive.dart
@@ -42,7 +42,7 @@ class RecursiveAstParser {
   }
 
   CloseElementAst parseCloseElement(NgToken beginToken) {
-    final nameToken = _reader.expect(NgTokenType.elementIdentifier);
+    var nameToken = _reader.expect(NgTokenType.elementIdentifier);
     if (_voidElements.contains(nameToken.lexeme)) {
       exceptionHandler.handle(new FormatException(
         "${nameToken.lexeme} is a void element and cannot be used in a close element tag",

--- a/lib/src/parser/recursive.dart
+++ b/lib/src/parser/recursive.dart
@@ -298,7 +298,6 @@ class RecursiveAstParser {
       beginToken,
       nameToken,
       endToken,
-      isVoidElement: isVoidElement,
       attributes: attributes,
       childNodes: childNodes,
       events: events,
@@ -436,8 +435,7 @@ class RecursiveAstParser {
 
   StandaloneTemplateAst _handleDanglingCloseElement(NgToken closeStart) {
     var closeElementAst = parseCloseElement(closeStart);
-    var synthElementAst = new ElementAst(closeElementAst.name);
-    synthElementAst.closeComplement = closeElementAst;
+    var synthElementAst = new ElementAst(closeElementAst.name, closeElementAst);
     return synthElementAst;
   }
 

--- a/lib/src/parser/recursive.dart
+++ b/lib/src/parser/recursive.dart
@@ -406,9 +406,6 @@ class RecursiveAstParser {
   }
 
   /// Returns and parses a top-level AST structure.
-  ///
-  /// [CloseElementAst] is returned if and only if it cannot be
-  /// matched to an [ElementAst] and only if errorRecovery is enabled.
   StandaloneTemplateAst parseStandalone(NgToken token) {
     switch (token.type) {
       case NgTokenType.commentStart:
@@ -419,7 +416,9 @@ class RecursiveAstParser {
         return parseInterpolation(token);
       case NgTokenType.text:
         return parseText(token);
-      // Always an error case
+      // Dangling close tag. If error recovery is enabled, returns
+      // a synthetic open with the dangling close. If not enabled,
+      // simply throws error.
       case NgTokenType.closeElementStart:
         exceptionHandler.handle(new FormatException(
           "Close element cannot exist before matching open element",

--- a/lib/src/parser/recursive.dart
+++ b/lib/src/parser/recursive.dart
@@ -14,8 +14,12 @@ class RecursiveAstParser {
   final List<String> _voidElements;
   final exceptionHandler;
 
-  RecursiveAstParser(SourceFile sourceFile, Iterable<NgToken> tokens,
-      this._voidElements, this.exceptionHandler)
+  RecursiveAstParser(
+    SourceFile sourceFile,
+    Iterable<NgToken> tokens,
+    this._voidElements,
+    this.exceptionHandler,
+  )
       : _reader = new NgTokenReversibleReader(sourceFile, tokens),
         _source = sourceFile;
 
@@ -391,8 +395,7 @@ class RecursiveAstParser {
   InterpolationAst parseInterpolation(NgToken beginToken) {
     final valueToken = _reader.expect(NgTokenType.interpolationValue);
     final endToken = _reader.expect(NgTokenType.interpolationEnd);
-    ExpressionAst expressionAst =
-        parseExpression(valueToken?.lexeme);
+    ExpressionAst expressionAst = parseExpression(valueToken?.lexeme);
     return new InterpolationAst.parsed(
       _source,
       beginToken,

--- a/lib/src/parser/recursive.dart
+++ b/lib/src/parser/recursive.dart
@@ -114,13 +114,6 @@ class RecursiveAstParser {
       NgTokenType prefixType = prefixToken.type;
 
       if (prefixType == NgTokenType.bananaPrefix) {
-        ExpressionAst eventExpression;
-        ExpressionAst propertyExpression;
-        if (valueToken != null) {
-          eventExpression =
-              parseExpression('${valueToken.innerValue?.lexeme} = \$event');
-          propertyExpression = parseExpression(valueToken.innerValue?.lexeme);
-        }
         return new BananaAst.parsed(
           _source,
           beginToken,
@@ -128,8 +121,6 @@ class RecursiveAstParser {
           decoratorToken,
           suffixToken,
           valueToken,
-          eventExpression,
-          propertyExpression,
           equalSignToken,
         );
       } else if (prefixType == NgTokenType.eventPrefix) {

--- a/lib/src/parser/recursive.dart
+++ b/lib/src/parser/recursive.dart
@@ -51,6 +51,8 @@ class RecursiveAstParser {
       ));
     }
 
+    //TODO: Max: remove entirely
+    @deprecated
     List<WhitespaceAst> whitespaces = <WhitespaceAst>[];
     while (_reader.peekType() == NgTokenType.whitespace) {
       whitespaces.add(new WhitespaceAst(_source, _reader.next()));

--- a/lib/src/parser/recursive.dart
+++ b/lib/src/parser/recursive.dart
@@ -206,10 +206,12 @@ class RecursiveAstParser {
           attributes.add(decoratorAst);
         } else if (decoratorAst is StarAst) {
           if (stars.isNotEmpty) {
-            _reader.error(''
-                'Already found an *-directive, limit 1 per element, but also '
-                'found ${decoratorAst.sourceSpan.highlight()}');
-            return null;
+            exceptionHandler.handle(new FormatException(
+              'Already found an *-directive, limit 1 per element, but also '
+                  'found ${decoratorAst.sourceSpan.highlight()}',
+              _source.getText(0),
+              decoratorAst.beginToken.offset,
+            ));
           }
           stars.add(decoratorAst);
         } else if (decoratorAst is EventAst) {

--- a/lib/src/parser/recursive.dart
+++ b/lib/src/parser/recursive.dart
@@ -283,7 +283,7 @@ class RecursiveAstParser {
             _source.getText(0),
             closeNameToken.offset,
           ));
-          _reader.putBack(nextToken);
+          childNodes.add(parseStandalone(nextToken));
           closeElementAst = new CloseElementAst(nameToken.lexeme);
         } else {
           closeElementAst = parseCloseElement(nextToken);

--- a/lib/src/simple_tokenizer.dart
+++ b/lib/src/simple_tokenizer.dart
@@ -83,7 +83,9 @@ class NgSimpleScanner {
           _scanner.peekChar(2) == $gt) {
         break;
       }
-      _scanner.position++;
+      if (_scanner.position < _scanner.string.length) {
+        _scanner.position++;
+      }
       if (_scanner.isDone) {
         _state = _NgSimpleScannerState.text;
         String substring = _scanner.string.substring(offset);

--- a/lib/src/visitor.dart
+++ b/lib/src/visitor.dart
@@ -21,6 +21,9 @@ abstract class TemplateAstVisitor<R, C> {
   /// **NOTE**: When de-sugared, this will never occur in a template tree.
   R visitBanana(BananaAst astNode, [C context]);
 
+  /// Visits all closeElement ASTS.
+  R visitCloseElement(CloseElementAst astNode, [C context]);
+
   /// Visits all comment ASTs.
   R visitComment(CommentAst astNode, [C context]);
 

--- a/lib/src/visitors/desugar_visitor.dart
+++ b/lib/src/visitors/desugar_visitor.dart
@@ -23,15 +23,12 @@ class DesugarVisitor extends TemplateAstVisitor<TemplateAst, String> {
   TemplateAst visitBanana(BananaAst astNode, [String flag]) {
     TemplateAst origin = _toolFriendlyAstOrigin ? astNode : null;
     if (flag == "event") {
-      return new EventAst.from(
-          origin,
-          astNode.name + 'Changed',
-          new ExpressionAst.parse('${astNode.value} = \$event',
-              sourceUrl: astNode.sourceUrl));
+      return new EventAst.from(origin, astNode.name + 'Changed',
+          '${astNode.value} = \$event', astNode.eventExpression);
     }
     if (flag == "property") {
-      return new PropertyAst.from(origin, astNode.name,
-          new ExpressionAst.parse(astNode.value, sourceUrl: astNode.sourceUrl));
+      return new PropertyAst.from(
+          origin, astNode.name, astNode.value, astNode.propertyExpression);
     }
     return astNode;
   }
@@ -87,6 +84,7 @@ class DesugarVisitor extends TemplateAstVisitor<TemplateAst, String> {
           properties: [
             new PropertyAst(
               directiveName,
+              starExpression,
               new ExpressionAst.parse(
                 starExpression,
                 sourceUrl: astNode.sourceUrl,

--- a/lib/src/visitors/desugar_visitor.dart
+++ b/lib/src/visitors/desugar_visitor.dart
@@ -39,12 +39,20 @@ class DesugarVisitor extends TemplateAstVisitor<TemplateAst, String> {
         exceptionHandler.handle(e);
       }
       if (flag == "event") {
-        return new EventAst.from(origin, astNode.name + 'Changed',
-            '${astNode.value}', expressionAst);
+        return new EventAst.from(
+          origin,
+          astNode.name + 'Changed',
+          astNode.value + appendedValue,
+          expressionAst,
+        );
       }
       if (flag == "property") {
         return new PropertyAst.from(
-            origin, astNode.name, astNode.value, expressionAst);
+          origin,
+          astNode.name,
+          astNode.value,
+          expressionAst,
+        );
       }
     }
 

--- a/lib/src/visitors/desugar_visitor.dart
+++ b/lib/src/visitors/desugar_visitor.dart
@@ -37,6 +37,9 @@ class DesugarVisitor extends TemplateAstVisitor<TemplateAst, String> {
   }
 
   @override
+  TemplateAst visitCloseElement(CloseElementAst astNode, [_]) => astNode;
+
+  @override
   TemplateAst visitComment(CommentAst astNode, [_]) => astNode;
 
   @override

--- a/lib/src/visitors/desugar_visitor.dart
+++ b/lib/src/visitors/desugar_visitor.dart
@@ -88,10 +88,10 @@ class DesugarVisitor extends TemplateAstVisitor<TemplateAst, String> {
         } catch (e) {
           exceptionHandler.handle(e);
         }
-        List<PropertyAst> properties = micro == null ?
-          <PropertyAst>[] : micro.properties;
-        List<ReferenceAst> references = micro == null ?
-          <ReferenceAst>[] : micro.assignments;
+        List<PropertyAst> properties =
+            micro == null ? <PropertyAst>[] : micro.properties;
+        List<ReferenceAst> references =
+            micro == null ? <ReferenceAst>[] : micro.assignments;
         newAst = new EmbeddedTemplateAst.from(
           origin,
           childNodes: [

--- a/lib/src/visitors/humanizing.dart
+++ b/lib/src/visitors/humanizing.dart
@@ -170,10 +170,10 @@ class HumanizingTemplateAstVisitor
 
   @override
   String visitStar(StarAst astNode, [_]) {
-    if (astNode.expression == null) {
+    if (astNode.value == null) {
       return '*${astNode.name}';
     } else {
-      return '*${astNode.name}="${visitExpression(astNode.expression)}"';
+      return '*${astNode.name}="${astNode.value}"';
     }
   }
 

--- a/lib/src/visitors/humanizing.dart
+++ b/lib/src/visitors/humanizing.dart
@@ -24,6 +24,17 @@ class HumanizingTemplateAstVisitor
   }
 
   @override
+  String visitCloseElement(CloseElementAst astNode, [StringBuffer context]) {
+    context ??= new StringBuffer();
+    context..write('</')..write(astNode.name);
+    if (astNode.whitespaces.isNotEmpty) {
+      context..writeAll(astNode.whitespaces.map(visitWhitespace), ' ');
+    }
+    context.write('>');
+    return context.toString();
+  }
+
+  @override
   String visitComment(CommentAst astNode, [_]) {
     return '<!--${astNode.value}-->';
   }
@@ -65,11 +76,19 @@ class HumanizingTemplateAstVisitor
     if (astNode.whitespaces.isNotEmpty) {
       context..writeAll(astNode.whitespaces.map(visitWhitespace), ' ');
     }
-    context.write('>');
+    if (astNode.isVoidTag) {
+      if (astNode.isSynthetic) {
+        context.write('/>');
+      } else {
+        context.write(astNode.endToken.lexeme);
+      }
+    }
     if (astNode.childNodes.isNotEmpty) {
       context.writeAll(astNode.childNodes.map((c) => c.accept(this)));
     }
-    context..write('</')..write(astNode.name)..write('>');
+    if (astNode.closeComplement != null) {
+      context.write(visitCloseElement(astNode.closeComplement));
+    }
     return context.toString();
   }
 

--- a/lib/src/visitors/humanizing.dart
+++ b/lib/src/visitors/humanizing.dart
@@ -76,13 +76,7 @@ class HumanizingTemplateAstVisitor
     if (astNode.whitespaces.isNotEmpty) {
       context..writeAll(astNode.whitespaces.map(visitWhitespace), ' ');
     }
-    if (astNode.isVoidTag) {
-      if (astNode.isSynthetic) {
-        context.write('/>');
-      } else {
-        context.write(astNode.endToken.lexeme);
-      }
-    }
+    context.write(astNode.usesVoidTagEnd ? '/>' : '>');
     if (astNode.childNodes.isNotEmpty) {
       context.writeAll(astNode.childNodes.map((c) => c.accept(this)));
     }

--- a/lib/src/visitors/humanizing.dart
+++ b/lib/src/visitors/humanizing.dart
@@ -81,7 +81,13 @@ class HumanizingTemplateAstVisitor
     if (astNode.whitespaces.isNotEmpty) {
       context..writeAll(astNode.whitespaces.map(visitWhitespace), ' ');
     }
-    context.write(astNode.usesVoidTagEnd ? '/>' : '>');
+
+    if (astNode.isSynthetic && astNode.isVoidElement) {
+      context.write(astNode.isVoidElement ? '/>' : '>');
+    } else {
+      context.write(astNode.endToken.lexeme);
+    }
+
     if (astNode.childNodes.isNotEmpty) {
       context.writeAll(astNode.childNodes.map((c) => c.accept(this)));
     }

--- a/lib/src/visitors/humanizing.dart
+++ b/lib/src/visitors/humanizing.dart
@@ -20,7 +20,12 @@ class HumanizingTemplateAstVisitor
 
   @override
   String visitBanana(BananaAst astNode, [_]) {
-    return '[(${astNode.name})]="${astNode.value}"';
+    String name = '[(${astNode.name})]';
+    if (astNode.value != null) {
+      return '$name="${astNode.value}"';
+    } else {
+      return name;
+    }
   }
 
   @override
@@ -133,10 +138,11 @@ class HumanizingTemplateAstVisitor
 
   @override
   String visitEvent(EventAst astNode, [_]) {
-    if (astNode.expression != null) {
-      return '(${astNode.name})="${astNode.expression.expression.toSource()}"';
+    String name = '(${astNode.name})';
+    if (astNode.value != null) {
+      return '$name="${astNode.value}"';
     } else {
-      return '(${astNode.name})';
+      return name;
     }
   }
 
@@ -147,33 +153,36 @@ class HumanizingTemplateAstVisitor
 
   @override
   String visitInterpolation(InterpolationAst astNode, [_]) {
-    return '{{${astNode.expression.expression.toSource()}}}';
+    return '{{${astNode.value}}}';
   }
 
   @override
   String visitProperty(PropertyAst astNode, [_]) {
-    if (astNode.expression != null) {
-      return '[${astNode.name}]="${astNode.expression.expression.toSource()}"';
+    String name = '[${astNode.name}]';
+    if (astNode.value != null) {
+      return '$name="${astNode.value}"';
     } else {
-      return '[${astNode.name}]';
+      return name;
     }
   }
 
   @override
   String visitReference(ReferenceAst astNode, [_]) {
+    String identifier = '#${astNode.identifier}';
     if (astNode.variable != null) {
-      return '#${astNode.identifier}="${astNode.variable}"';
+      return '$identifier="${astNode.variable}"';
     } else {
-      return '#${astNode.identifier}';
+      return identifier;
     }
   }
 
   @override
   String visitStar(StarAst astNode, [_]) {
-    if (astNode.value == null) {
-      return '*${astNode.name}';
+    String name = '${astNode.name}';
+    if (astNode.value != null) {
+      return 'name="${astNode.value}"';
     } else {
-      return '*${astNode.name}="${astNode.value}"';
+      return name;
     }
   }
 

--- a/lib/src/visitors/humanizing.dart
+++ b/lib/src/visitors/humanizing.dart
@@ -133,7 +133,11 @@ class HumanizingTemplateAstVisitor
 
   @override
   String visitEvent(EventAst astNode, [_]) {
-    return '(${astNode.name})="${astNode.expression.expression.toSource()}"';
+    if (astNode.expression != null) {
+      return '(${astNode.name})="${astNode.expression.expression.toSource()}"';
+    } else {
+      return '(${astNode.name})';
+    }
   }
 
   @override

--- a/lib/src/visitors/identity.dart
+++ b/lib/src/visitors/identity.dart
@@ -19,6 +19,9 @@ class IdentityTemplateAstVisitor<C>
   TemplateAst visitBanana(BananaAst astNode, [_]) => astNode;
 
   @override
+  TemplateAst visitCloseElement(CloseElementAst astNode, [_]) => astNode;
+
+  @override
   TemplateAst visitComment(CommentAst astNode, [_]) => astNode;
 
   @override

--- a/test/ast_cli_tester.dart
+++ b/test/ast_cli_tester.dart
@@ -6,16 +6,14 @@ import 'dart:io';
 import 'dart:convert';
 import 'package:angular_ast/angular_ast.dart';
 
-RecoveringExceptionHandler exceptionHandler = new RecoveringExceptionHandler();
-//ThrowingExceptionHandler exceptionHandler = new ThrowingExceptionHandler();
+final exceptionHandler = new RecoveringExceptionHandler();
 
-List<StandaloneTemplateAst> parse(String template) {
-  return const NgParser().parsePreserve(
-    template,
-    sourceUrl: '/test/parser_test.dart#inline',
-    exceptionHandler: exceptionHandler,
-  );
-}
+List<StandaloneTemplateAst> parse(String template) =>
+    const NgParser().parsePreserve(
+      template,
+      sourceUrl: '/test/parser_test.dart#inline',
+      exceptionHandler: exceptionHandler,
+    );
 
 void main() {
   String input;
@@ -24,24 +22,24 @@ void main() {
       exceptionHandler.exceptions.clear();
     }
     input = stdin.readLineSync(encoding: UTF8);
-    if (input == "QUIT") {
+    if (input == 'QUIT') {
       break;
     }
     List<StandaloneTemplateAst> ast = parse(input);
     print("----------------------------------------------");
     if (exceptionHandler is ThrowingExceptionHandler) {
-      print("CORRECT!");
+      print('CORRECT!');
     }
     if (exceptionHandler is RecoveringExceptionHandler) {
       final exceptionsList = exceptionHandler.exceptions;
       if (exceptionsList.isEmpty) {
-        print("CORRECT!");
+        print('CORRECT!');
       } else {
         HumanizingTemplateAstVisitor visitor =
             const HumanizingTemplateAstVisitor();
         String fixed = ast.map((t) => t.accept(visitor)).join('');
-        print("ORGNL: " + input);
-        print("FIXED: " + fixed);
+        print('ORGNL: $input');
+        print('FIXED: $fixed');
       }
       print('\n\nERRORS:');
       print(exceptionHandler.exceptions);

--- a/test/ast_cli_tester.dart
+++ b/test/ast_cli_tester.dart
@@ -10,7 +10,7 @@ RecoveringExceptionHandler exceptionHandler = new RecoveringExceptionHandler();
 //ThrowingExceptionHandler exceptionHandler = new ThrowingExceptionHandler();
 
 List<StandaloneTemplateAst> parse(String template) {
-  return const NgParser().parse(
+  return const NgParser().parsePreserve(
     template,
     sourceUrl: '/test/parser_test.dart#inline',
     exceptionHandler: exceptionHandler,

--- a/test/ast_cli_tester.dart
+++ b/test/ast_cli_tester.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+import 'dart:convert';
+import 'package:angular_ast/angular_ast.dart';
+
+RecoveringExceptionHandler exceptionHandler = new RecoveringExceptionHandler();
+//ThrowingExceptionHandler exceptionHandler = new ThrowingExceptionHandler();
+
+List<StandaloneTemplateAst> parse(String template) {
+  return const NgParser().parse(
+    template,
+    sourceUrl: '/test/parser_test.dart#inline',
+    exceptionHandler: exceptionHandler,
+  );
+}
+
+void main() {
+  String input;
+  while (true) {
+    if (exceptionHandler is RecoveringExceptionHandler) {
+      exceptionHandler.exceptions.clear();
+    }
+    input = stdin.readLineSync(encoding: UTF8);
+    if (input == "QUIT") {
+      break;
+    }
+    List<StandaloneTemplateAst> ast = parse(input);
+    print("----------------------------------------------");
+    if (exceptionHandler is ThrowingExceptionHandler) {
+      print("CORRECT!");
+    }
+    if (exceptionHandler is RecoveringExceptionHandler) {
+      final exceptionsList = exceptionHandler.exceptions;
+      if (exceptionsList.isEmpty) {
+        print("CORRECT!");
+      } else {
+        HumanizingTemplateAstVisitor visitor =
+            const HumanizingTemplateAstVisitor();
+        String fixed = ast.map((t) => t.accept(visitor)).join('');
+        print("ORGNL: " + input);
+        print("FIXED: " + fixed);
+      }
+      print('\n\nERRORS:');
+      print(exceptionHandler.exceptions);
+    }
+  }
+}

--- a/test/expression/micro/parser_test.dart
+++ b/test/expression/micro/parser_test.dart
@@ -51,6 +51,7 @@ void main() {
         properties: [
           new PropertyAst(
             'ngForOf',
+            'items.where(filter)',
             new ExpressionAst.parse(
               'items.where(filter)',
               sourceUrl: '/test/expression/micro/parser_test.dart#inline',
@@ -71,6 +72,7 @@ void main() {
         properties: [
           new PropertyAst(
             'ngForOf',
+            'items',
             new ExpressionAst.parse(
               'items',
               sourceUrl: '/test/expression/micro/parser_test.dart#inline',
@@ -78,6 +80,7 @@ void main() {
           ),
           new PropertyAst(
             'ngForTrackBy',
+            'byId',
             new ExpressionAst.parse(
               'byId',
               sourceUrl: '/test/expression/micro/parser_test.dart#inline',

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -33,7 +33,7 @@ void main() {
     expect(
       parse('<div></div  >'),
       [
-        new ElementAst('div'),
+        new ElementAst('div', new CloseElementAst('div')),
       ],
     );
   });
@@ -77,7 +77,7 @@ void main() {
       parse('Hello<div></div><!--Goodbye-->{{name}}'),
       [
         new TextAst('Hello'),
-        new ElementAst('div'),
+        new ElementAst('div', new CloseElementAst('div')),
         new CommentAst('Goodbye'),
         new InterpolationAst(new ExpressionAst.parse(
           'name',
@@ -94,9 +94,9 @@ void main() {
           '  <span>Hello World</span>\n'
           '</div>\n'),
       [
-        new ElementAst('div', childNodes: [
+        new ElementAst('div', new CloseElementAst('div'), childNodes: [
           new TextAst('\n  '),
-          new ElementAst('span', childNodes: [
+          new ElementAst('span', new CloseElementAst('span'), childNodes: [
             new TextAst('Hello World'),
           ]),
           new TextAst('\n'),
@@ -110,7 +110,7 @@ void main() {
     expect(
       parse('<button disabled ></button>'),
       [
-        new ElementAst('button', attributes: [
+        new ElementAst('button', new CloseElementAst('button'), attributes: [
           new AttributeAst('disabled'),
         ]),
       ],
@@ -121,7 +121,7 @@ void main() {
     expect(
       parse('<button title="Submit"></button>'),
       [
-        new ElementAst('button', attributes: [
+        new ElementAst('button', new CloseElementAst('button'), attributes: [
           new AttributeAst('title', 'Submit'),
         ]),
       ],
@@ -132,7 +132,7 @@ void main() {
     expect(
       parse('<div title="Hello {{myName}}"></div>'),
       [
-        new ElementAst('div', attributes: [
+        new ElementAst('div', new CloseElementAst('div'), attributes: [
           new AttributeAst('title', 'Hello {{myName}}'),
         ]),
       ],
@@ -143,7 +143,7 @@ void main() {
     expect(
       parse('<button (click) = "onClick()"  ></button>'),
       [
-        new ElementAst('button', events: [
+        new ElementAst('button', new CloseElementAst('button'), events: [
           new EventAst(
               'click',
               'onClick()',
@@ -160,7 +160,7 @@ void main() {
     expect(
       parse('<button [value]></button>'),
       [
-        new ElementAst('button', properties: [
+        new ElementAst('button', new CloseElementAst('button'), properties: [
           new PropertyAst('value'),
         ]),
       ],
@@ -171,7 +171,7 @@ void main() {
     expect(
       parse('<button [value]="btnValue"></button>'),
       [
-        new ElementAst('button', properties: [
+        new ElementAst('button', new CloseElementAst('button'), properties: [
           new PropertyAst(
               'value',
               'btnValue',
@@ -188,7 +188,7 @@ void main() {
     expect(
       parse('<button #btnRef></button>'),
       [
-        new ElementAst('button', references: [
+        new ElementAst('button', new CloseElementAst('button'), references: [
           new ReferenceAst('btnRef'),
         ]),
       ],
@@ -199,9 +199,10 @@ void main() {
     expect(
       parse('<mat-button #btnRef="mat-button"></mat-button>'),
       [
-        new ElementAst('mat-button', references: [
-          new ReferenceAst('btnRef', 'mat-button'),
-        ]),
+        new ElementAst('mat-button', new CloseElementAst('mat-button'),
+            references: [
+              new ReferenceAst('btnRef', 'mat-button'),
+            ]),
       ],
     );
   });
@@ -289,8 +290,8 @@ void main() {
     expect(
       parse('<input><div></div>'),
       [
-        new ElementAst('input', isVoidElement: true),
-        new ElementAst('div'),
+        new ElementAst('input', null),
+        new ElementAst('div', new CloseElementAst('div')),
       ],
     );
   });
@@ -301,6 +302,7 @@ void main() {
       [
         new ElementAst(
           'custom',
+          new CloseElementAst('custom'),
           events: [
             new EventAst(
                 'nameChanged',
@@ -333,7 +335,7 @@ void main() {
             new AttributeAst('ngFor'),
           ],
           childNodes: [
-            new ElementAst('a'),
+            new ElementAst('a', new CloseElementAst('a')),
           ],
           properties: [
             new PropertyAst(

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -286,7 +286,7 @@ void main() {
     expect(
       parse('<input><div></div>'),
       [
-        new ElementAst('input'),
+        new ElementAst('input', isVoidElement: true),
         new ElementAst('div'),
       ],
     );
@@ -383,9 +383,9 @@ void main() {
 
     expect(element.whitespaces[0].offset, 127);
 
-    expect(element.openTagEndOffset, 129);
-    expect(element.closeTagStartOffset, 130);
-    expect(element.endToken.offset, 142);
+    expect(element.endToken.offset, 129);
+    expect(element.closeComplement.beginToken.offset, 130);
+    expect(element.closeComplement.endToken.offset, 142);
   });
 
   test('should parse and preserve strict offsets within interpolations', () {

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -405,5 +405,6 @@ void main() {
     expect(interpolation.beginToken.offset, 5);
     expect(interpolation.value.length, 15);
     expect(interpolation.endToken.offset, 22);
+    expect(interpolation.expression, isNotNull);
   });
 }

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -146,6 +146,7 @@ void main() {
         new ElementAst('button', events: [
           new EventAst(
               'click',
+              'onClick()',
               new ExpressionAst.parse(
                 'onClick()',
                 sourceUrl: '/test/expression/parser_test.dart#inline',
@@ -173,6 +174,7 @@ void main() {
         new ElementAst('button', properties: [
           new PropertyAst(
               'value',
+              'btnValue',
               new ExpressionAst.parse(
                 'btnValue',
                 sourceUrl: '/test/expression/parser_test.dart#inline',
@@ -239,6 +241,7 @@ void main() {
           properties: [
             new PropertyAst(
                 'ngIf',
+                'someValue',
                 new ExpressionAst.parse(
                   'someValue',
                   sourceUrl: '/test/expression/parser_test.dart#inline',
@@ -301,6 +304,7 @@ void main() {
           events: [
             new EventAst(
                 'nameChanged',
+                'myName = \$event',
                 new ExpressionAst.parse(
                   'myName = \$event',
                   sourceUrl: '/test/expression/parser_test.dart#inline',
@@ -309,6 +313,7 @@ void main() {
           properties: [
             new PropertyAst(
                 'name',
+                'myName',
                 new ExpressionAst.parse(
                   'myName',
                   sourceUrl: '/test/expression/parser_test.dart#inline',
@@ -333,6 +338,7 @@ void main() {
           properties: [
             new PropertyAst(
               'ngForOf',
+              'items',
               new ExpressionAst.parse(
                 'items',
                 sourceUrl: '/test/expression/parser_test.dart#inline',
@@ -340,6 +346,7 @@ void main() {
             ),
             new PropertyAst(
               'ngForTrackBy',
+              'byId',
               new ExpressionAst.parse(
                 'byId',
                 sourceUrl: '/test/expression/parser_test.dart#inline',

--- a/test/random_generator_test/random_tester.dart
+++ b/test/random_generator_test/random_tester.dart
@@ -1,0 +1,201 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:core';
+import 'dart:math';
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+import 'package:angular_ast/angular_ast.dart';
+import 'package:angular_ast/src/token/tokens.dart';
+
+final int generationCount = 10000;
+final int iterationCount = 50;
+
+final dir = p.join('test', 'random_generator_test');
+String incorrectFilename = "incorrect.html";
+String lexerFixedFilename = "lexer_fixed.html";
+String fullyFixedFilename = "ast_fixed.html";
+
+String untokenize(Iterable<NgToken> tokens) => tokens
+    .fold(new StringBuffer(), (buffer, token) => buffer..write(token.lexeme))
+    .toString();
+
+enum State {
+  comment,
+  element,
+  interpolation,
+  text,
+}
+
+String genericExpression = " + 1 + 2";
+
+final elementMap = <NgSimpleTokenType>[
+  NgSimpleTokenType.bang,
+  NgSimpleTokenType.closeBanana,
+  NgSimpleTokenType.closeBracket,
+  NgSimpleTokenType.closeParen,
+  NgSimpleTokenType.commentBegin, //Shift state
+  NgSimpleTokenType.dash,
+  NgSimpleTokenType.doubleQuote, // special
+  NgSimpleTokenType.openTagStart,
+  NgSimpleTokenType.tagEnd,
+  NgSimpleTokenType.equalSign,
+  NgSimpleTokenType.forwardSlash,
+  NgSimpleTokenType.hash,
+  NgSimpleTokenType.identifier,
+  NgSimpleTokenType.openBanana,
+  NgSimpleTokenType.openBracket,
+  NgSimpleTokenType.openParen,
+  NgSimpleTokenType.period,
+  NgSimpleTokenType.singleQuote, //Special
+  NgSimpleTokenType.star,
+  NgSimpleTokenType.unexpectedChar,
+  NgSimpleTokenType.voidCloseTag,
+];
+
+final textMap = <NgSimpleTokenType>[
+  NgSimpleTokenType.commentBegin,
+  NgSimpleTokenType.openTagStart,
+  NgSimpleTokenType.closeTagStart,
+  NgSimpleTokenType.mustacheBegin,
+  NgSimpleTokenType.text,
+];
+
+NgSimpleTokenType generateRandomSimple(State state) {
+  Random rng = new Random();
+  switch (state) {
+    case State.comment:
+      if (rng.nextInt(100) <= 20) {
+        return NgSimpleTokenType.text;
+      }
+      return NgSimpleTokenType.commentEnd;
+    case State.element:
+      int i = rng.nextInt(elementMap.length);
+      return elementMap[i];
+    case State.interpolation:
+      if (rng.nextInt(100) <= 20) {
+        return NgSimpleTokenType.text;
+      }
+      return NgSimpleTokenType.mustacheEnd;
+    case State.text:
+      int i = rng.nextInt(textMap.length);
+      return textMap[i];
+    default:
+      return NgSimpleTokenType.unexpectedChar;
+  }
+}
+
+String generateHtmlString() {
+  State state = State.text;
+  StringBuffer sb = new StringBuffer();
+  int identifierCount = 0;
+  for (int i = 0; i < generationCount; i++) {
+    NgSimpleTokenType type = generateRandomSimple(state);
+    switch (state) {
+      case State.comment:
+        if (type == NgSimpleTokenType.commentEnd) {
+          state = State.text;
+          sb.write(NgSimpleToken.lexemeMap[type]);
+        } else {
+          sb.write(" some comment");
+        }
+        break;
+      case State.element:
+        if (type == NgSimpleTokenType.commentBegin) {
+          state = State.comment;
+          sb.write(NgSimpleToken.lexemeMap[type]);
+        } else if (type == NgSimpleTokenType.doubleQuote) {
+          sb.write('"someDoubleQuoteValue"');
+        } else if (type == NgSimpleTokenType.singleQuote) {
+          sb.write("'someSingleQuoteValue'");
+        } else if (type == NgSimpleTokenType.identifier) {
+          sb.write("ident" + identifierCount.toString());
+          identifierCount++;
+        } else if (type == NgSimpleTokenType.whitespace) {
+          sb.write(' ');
+        } else if (type == NgSimpleTokenType.voidCloseTag ||
+            type == NgSimpleTokenType.tagEnd) {
+          state = State.text;
+          sb.write(NgSimpleToken.lexemeMap[type]);
+        } else {
+          sb.write(NgSimpleToken.lexemeMap[type]);
+        }
+        break;
+      case State.interpolation:
+        if (type == NgSimpleTokenType.mustacheEnd) {
+          state = State.text;
+          sb.write(NgSimpleToken.lexemeMap[type]);
+        } else {
+          sb.write(genericExpression);
+        }
+        break;
+      case State.text:
+        if (type == NgSimpleTokenType.commentBegin) {
+          state = State.comment;
+          sb.write(NgSimpleToken.lexemeMap[type]);
+        } else if (type == NgSimpleTokenType.openTagStart ||
+            type == NgSimpleTokenType.closeTagStart) {
+          state = State.element;
+          sb.write(NgSimpleToken.lexemeMap[type]);
+        } else if (type == NgSimpleTokenType.mustacheBegin) {
+          state = State.interpolation;
+          sb.write(NgSimpleToken.lexemeMap[type] + '0');
+        } else {
+          sb.write("lorem ipsum");
+        }
+        break;
+      default:
+        sb.write('');
+    }
+  }
+  return sb.toString();
+}
+
+main() async {
+  RecoveringExceptionHandler exceptionHandler =
+      new RecoveringExceptionHandler();
+
+  int totalIncorrectLength = 0;
+  int totalLexerTime = 0;
+  int totalParserTime = 0;
+
+  for (int i = 0; i < iterationCount; i++) {
+    print("Iteration $i of $iterationCount ...");
+    Stopwatch stopwatch = new Stopwatch();
+
+    String incorrectHtml = generateHtmlString();
+    totalIncorrectLength += incorrectHtml.length;
+    await new File(p.join(dir, incorrectFilename)).writeAsString(incorrectHtml);
+
+    stopwatch.reset();
+    stopwatch.start();
+    Iterable<NgToken> lexerTokens =
+        const NgLexer().tokenize(incorrectHtml, exceptionHandler);
+    stopwatch.stop();
+    totalLexerTime += stopwatch.elapsedMicroseconds;
+    String lexerFixedString = untokenize(lexerTokens);
+    await new File(p.join(dir, lexerFixedFilename))
+        .writeAsString(lexerFixedString);
+    exceptionHandler.exceptions.clear();
+
+    stopwatch.reset();
+    stopwatch.start();
+    List<StandaloneTemplateAst> ast = const NgParser().parsePreserve(
+      incorrectHtml,
+      sourceUrl: '/test/parser_test.dart#inline',
+      exceptionHandler: exceptionHandler,
+    );
+    stopwatch.stop();
+    totalParserTime += stopwatch.elapsedMilliseconds;
+    HumanizingTemplateAstVisitor visitor = const HumanizingTemplateAstVisitor();
+    String fixedString = ast.map((t) => t.accept(visitor)).join('');
+    await new File(p.join(dir, fullyFixedFilename)).writeAsString(fixedString);
+    exceptionHandler.exceptions.clear();
+  }
+
+  print("Total lines scanned/parsed: $totalIncorrectLength");
+  print("Total time for lexer: $totalLexerTime microseconds");
+  print("Total time for parser: $totalParserTime ms");
+}

--- a/test/recover_errors_parser.dart
+++ b/test/recover_errors_parser.dart
@@ -64,8 +64,7 @@ void main() {
     expect(asts.length, 1);
 
     ElementAst element = asts[0];
-    expect(element,
-        new ElementAst('hr', isVoidElement: true, usesVoidTagEnd: true));
+    expect(element, new ElementAst('hr', isVoidElement: true));
     expect(element.closeComplement, null);
   });
 

--- a/test/recover_errors_parser.dart
+++ b/test/recover_errors_parser.dart
@@ -174,7 +174,7 @@ void main() {
     expect(element.stars[0].value, 'let[');
 
     EmbeddedTemplateAst template =
-      element.accept(desugarVisitor) as EmbeddedTemplateAst;
+        element.accept(desugarVisitor) as EmbeddedTemplateAst;
     expect(template.properties.length, 0);
     expect(template.references.length, 0);
 

--- a/test/recover_errors_parser.dart
+++ b/test/recover_errors_parser.dart
@@ -1,0 +1,78 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:angular_ast/angular_ast.dart';
+import 'package:test/test.dart';
+
+RecoveringExceptionHandler recoveringExceptionHandler =
+    new RecoveringExceptionHandler();
+
+List<StandaloneTemplateAst> parse(String template) {
+  return const NgParser().parse(
+    template,
+    sourceUrl: '/test/recover_error_Parser.dart#inline',
+    exceptionHandler: recoveringExceptionHandler,
+  );
+}
+
+String astsToString(List<StandaloneTemplateAst> asts) {
+  HumanizingTemplateAstVisitor visitor = const HumanizingTemplateAstVisitor();
+  return asts.map((t) => t.accept(visitor)).join('');
+}
+
+void main() {
+  test('Should close unclosed element tag', () {
+    final asts = parse('<div>');
+    expect(asts.length, 1);
+
+    ElementAst element = asts[0];
+    expect(element, new ElementAst('div'));
+    expect(element.closeComplement, new CloseElementAst('div'));
+    expect(element.isSynthetic, false);
+    expect(element.closeComplement.isSynthetic, true);
+    expect(astsToString(asts), '<div></div>');
+  });
+
+  test('Should add open element tag to dangling close tag', () {
+    final asts = parse('</div>');
+    expect(asts.length, 1);
+
+    ElementAst element = asts[0];
+    expect(element, new ElementAst('div'));
+    expect(element.closeComplement, new CloseElementAst('div'));
+    expect(element.isSynthetic, true);
+    expect(element.closeComplement.isSynthetic, false);
+    expect(astsToString(asts), '<div></div>');
+  });
+
+  test('Should not close a void tag', () {
+    final asts = parse('<hr/>');
+    expect(asts.length, 1);
+
+    ElementAst element = asts[0];
+    expect(element,
+        new ElementAst('hr', isVoidElement: true, usesVoidTagEnd: true));
+    expect(element.closeComplement, null);
+  });
+
+  test('Should add close tag to dangling open within nested', () {
+    final asts = parse('<div><div><div>text1</div>text2</div>');
+    expect(asts.length, 1);
+
+    ElementAst element = asts[0];
+    expect(element.childNodes.length, 1);
+    expect(element.childNodes[0].childNodes.length, 2);
+    expect(element.closeComplement.isSynthetic, true);
+    expect(astsToString(asts), '<div><div><div>text1</div>text2</div></div>');
+  });
+
+  test('Should add synthetic open to dangling close within nested', () {
+    final asts = parse('<div><div></div>text1</div>text2</div>');
+    expect(asts.length, 3);
+
+    ElementAst element = asts[2];
+    expect(element.isSynthetic, true);
+    expect(element.closeComplement.isSynthetic, false);
+  });
+}

--- a/test/recover_errors_parser.dart
+++ b/test/recover_errors_parser.dart
@@ -40,7 +40,7 @@ void main() {
     expect(asts.length, 1);
 
     ElementAst element = asts[0];
-    expect(element, new ElementAst('div'));
+    expect(element, new ElementAst('div', new CloseElementAst('div')));
     expect(element.closeComplement, new CloseElementAst('div'));
     expect(element.isSynthetic, false);
     expect(element.closeComplement.isSynthetic, true);
@@ -52,7 +52,7 @@ void main() {
     expect(asts.length, 1);
 
     ElementAst element = asts[0];
-    expect(element, new ElementAst('div'));
+    expect(element, new ElementAst('div', new CloseElementAst('div')));
     expect(element.closeComplement, new CloseElementAst('div'));
     expect(element.isSynthetic, true);
     expect(element.closeComplement.isSynthetic, false);
@@ -64,7 +64,7 @@ void main() {
     expect(asts.length, 1);
 
     ElementAst element = asts[0];
-    expect(element, new ElementAst('hr', isVoidElement: true));
+    expect(element, new ElementAst('hr', new CloseElementAst('hr')));
     expect(element.closeComplement, null);
   });
 

--- a/test/visitor_test.dart
+++ b/test/visitor_test.dart
@@ -6,6 +6,7 @@ import 'package:angular_ast/angular_ast.dart';
 import 'package:test/test.dart';
 
 void main() {
+  // DesugarVisitor is tested by parser_test.dart
   final visitor = const HumanizingTemplateAstVisitor();
 
   test('should humanize a simple template and preserve inner spaces', () {


### PR DESCRIPTION
Changes in this PR: 
- Error handling of dangling open/close elements that occurs at the AST level. Synthetics added as placeholders. Refer to `recover_errors_parser.dart` for sample cases.
- Added `CloseElementAst` which is linked to `ElementAst` as a field. This separates the open component and the close component - allowing for better insertion of synthetics and error recovery.
- Added CLI tester for ast level parsing, refer to `ast_cli_tester.dart`.
- Added randomized token generator and parser to check for edge cases as well as benchmarking. Could still be improved in future iteration. Refer to `test/random_generator_test/...`
- Error handling at the ExpressionAst.parse level. If error-recovery is enabled, ast will continue to be parsed even if expression parsing fails. 
- Related to above, `String value` is added as a field to any AST that holds an expressionAst field. This ensures that there is still a link to the String version of the value even if the ExpressionAst fails to parse (in which case it would be null). 

Needed changes:
- Better handle void element cases. Not all void elements are tracked by list in `parser.dart` file. 
- Improve on error recovery of NgContent and Templates(after desugaring occurs).

Future changes for better performance:
- Change Token types to enums rather than string.
- Change error accumulation to not use Exception class, but a custom lightweight class.