### PR TITLE
Allow for parsing of % and backslash in css

### DIFF
--- a/lib/src/recovery_protocol/angular_analyzer_protocol.dart
+++ b/lib/src/recovery_protocol/angular_analyzer_protocol.dart
@@ -429,7 +429,9 @@ class NgAnalyzerRecoveryProtocol extends RecoveryProtocol {
         type == NgSimpleTokenType.dash ||
         type == NgSimpleTokenType.forwardSlash ||
         type == NgSimpleTokenType.period ||
-        type == NgSimpleTokenType.unexpectedChar) {
+        type == NgSimpleTokenType.unexpectedChar ||
+        type == NgSimpleTokenType.percent ||
+        type == NgSimpleTokenType.backSlash) {
       return new RecoverySolution.skip();
     }
     reader.putBack(current);
@@ -449,7 +451,9 @@ class NgAnalyzerRecoveryProtocol extends RecoveryProtocol {
     if (type == NgSimpleTokenType.bang ||
         type == NgSimpleTokenType.dash ||
         type == NgSimpleTokenType.forwardSlash ||
-        type == NgSimpleTokenType.unexpectedChar) {
+        type == NgSimpleTokenType.unexpectedChar ||
+        type == NgSimpleTokenType.percent ||
+        type == NgSimpleTokenType.backSlash) {
       return new RecoverySolution.skip();
     }
     reader.putBack(current);
@@ -469,7 +473,9 @@ class NgAnalyzerRecoveryProtocol extends RecoveryProtocol {
     if (type == NgSimpleTokenType.bang ||
         type == NgSimpleTokenType.dash ||
         type == NgSimpleTokenType.forwardSlash ||
-        type == NgSimpleTokenType.unexpectedChar) {
+        type == NgSimpleTokenType.unexpectedChar ||
+        type == NgSimpleTokenType.percent ||
+        type == NgSimpleTokenType.backSlash) {
       return new RecoverySolution.skip();
     }
     reader.putBack(current);
@@ -489,7 +495,9 @@ class NgAnalyzerRecoveryProtocol extends RecoveryProtocol {
     if (type == NgSimpleTokenType.bang ||
         type == NgSimpleTokenType.dash ||
         type == NgSimpleTokenType.forwardSlash ||
-        type == NgSimpleTokenType.unexpectedChar) {
+        type == NgSimpleTokenType.unexpectedChar ||
+        type == NgSimpleTokenType.percent ||
+        type == NgSimpleTokenType.backSlash) {
       return new RecoverySolution.skip();
     }
     reader.putBack(current);
@@ -515,7 +523,9 @@ class NgAnalyzerRecoveryProtocol extends RecoveryProtocol {
     if (type == NgSimpleTokenType.bang ||
         type == NgSimpleTokenType.forwardSlash ||
         type == NgSimpleTokenType.dash ||
-        type == NgSimpleTokenType.unexpectedChar) {
+        type == NgSimpleTokenType.unexpectedChar ||
+        type == NgSimpleTokenType.percent ||
+        type == NgSimpleTokenType.backSlash) {
       return new RecoverySolution.skip();
     }
     reader.putBack(current);
@@ -535,7 +545,9 @@ class NgAnalyzerRecoveryProtocol extends RecoveryProtocol {
     if (type == NgSimpleTokenType.bang ||
         type == NgSimpleTokenType.forwardSlash ||
         type == NgSimpleTokenType.dash ||
-        type == NgSimpleTokenType.unexpectedChar) {
+        type == NgSimpleTokenType.unexpectedChar ||
+        type == NgSimpleTokenType.percent ||
+        type == NgSimpleTokenType.backSlash) {
       return new RecoverySolution.skip();
     }
     reader.putBack(current);
@@ -555,7 +567,9 @@ class NgAnalyzerRecoveryProtocol extends RecoveryProtocol {
     if (type == NgSimpleTokenType.bang ||
         type == NgSimpleTokenType.forwardSlash ||
         type == NgSimpleTokenType.dash ||
-        type == NgSimpleTokenType.unexpectedChar) {
+        type == NgSimpleTokenType.unexpectedChar ||
+        type == NgSimpleTokenType.percent ||
+        type == NgSimpleTokenType.backSlash) {
       return new RecoverySolution.skip();
     }
 

--- a/lib/src/scanner.dart
+++ b/lib/src/scanner.dart
@@ -493,7 +493,9 @@ class NgScanner {
     sb.write(_current.lexeme);
     while (_reader.peekType() == NgSimpleTokenType.period ||
         _reader.peekType() == NgSimpleTokenType.identifier ||
-        _reader.peekType() == NgSimpleTokenType.dash) {
+        _reader.peekType() == NgSimpleTokenType.dash ||
+        _reader.peekType() == NgSimpleTokenType.percent ||
+        _reader.peekType() == NgSimpleTokenType.backSlash) {
       _moveNext();
       sb.write(_current.lexeme);
     }

--- a/lib/src/simple_tokenizer.dart
+++ b/lib/src/simple_tokenizer.dart
@@ -46,7 +46,9 @@ class NgSimpleScanner {
       r'(=)|' //17 =
       r'(\*)|' //18 *
       r'(\#)|' //19 #
-      r'(\.)'); //20 .
+      r'(\.)|' //20 .
+      r'(\%)|' //21 %
+      r'(\\)'); //22 \
   static final _commentEnd = new RegExp('-->');
   static final _mustaches = new RegExp(r'({{)|(}})');
   static final _newline = new RegExp('\n');
@@ -221,6 +223,12 @@ class NgSimpleScanner {
       }
       if (matchesGroup(match, 20)) {
         return new NgSimpleToken.period(offset);
+      }
+      if (matchesGroup(match, 21)) {
+        return new NgSimpleToken.percent(offset);
+      }
+      if (matchesGroup(match, 22)) {
+        return new NgSimpleToken.backSlash(offset);
       }
     }
     return new NgSimpleToken.unexpectedChar(

--- a/lib/src/token/token_types.dart
+++ b/lib/src/token/token_types.dart
@@ -7,6 +7,7 @@ part of angular_ast.src.token.tokens;
 /// The types of tokens that can be returned by the NgStringTokenizer
 enum NgSimpleTokenType {
   bang,
+  backSlash,
   closeBanana,
   closeBrace,
   closeBracket,
@@ -30,6 +31,7 @@ enum NgSimpleTokenType {
   openBracket,
   openParen,
   period,
+  percent,
   singleQuote,
   star,
   text,

--- a/lib/src/token/tokens.dart
+++ b/lib/src/token/tokens.dart
@@ -21,6 +21,7 @@ abstract class NgBaseToken<TokenType> {
 /// Clients should not extend, implement, or mix-in this class.
 class NgSimpleToken implements NgBaseToken<NgSimpleTokenType> {
   static final Map<NgSimpleTokenType, String> lexemeMap = const {
+    NgSimpleTokenType.backSlash: '\\',
     NgSimpleTokenType.bang: '!',
     NgSimpleTokenType.closeBanana: ')]',
     NgSimpleTokenType.closeBracket: ']',
@@ -41,6 +42,7 @@ class NgSimpleToken implements NgBaseToken<NgSimpleTokenType> {
     NgSimpleTokenType.openBanana: '[(',
     NgSimpleTokenType.openBracket: '[',
     NgSimpleTokenType.openParen: '(',
+    NgSimpleTokenType.percent: '%',
     NgSimpleTokenType.period: '.',
     NgSimpleTokenType.star: '*',
     NgSimpleTokenType.text: '',
@@ -48,6 +50,10 @@ class NgSimpleToken implements NgBaseToken<NgSimpleTokenType> {
     NgSimpleTokenType.voidCloseTag: '/>',
     NgSimpleTokenType.whitespace: ' ',
   };
+
+  factory NgSimpleToken.backSlash(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.bang, offset);
+  }
 
   factory NgSimpleToken.bang(int offset) {
     return new NgSimpleToken._(NgSimpleTokenType.bang, offset);
@@ -128,6 +134,10 @@ class NgSimpleToken implements NgBaseToken<NgSimpleTokenType> {
 
   factory NgSimpleToken.openParen(int offset) {
     return new NgSimpleToken._(NgSimpleTokenType.openParen, offset);
+  }
+
+  factory NgSimpleToken.percent(int offset) {
+    return new NgSimpleToken._(NgSimpleTokenType.percent, offset);
   }
 
   factory NgSimpleToken.period(int offset) {

--- a/test/random_generator_test/random_tester.dart
+++ b/test/random_generator_test/random_tester.dart
@@ -11,7 +11,7 @@ import 'package:angular_ast/angular_ast.dart';
 import 'package:angular_ast/src/token/tokens.dart';
 
 final int generationCount = 10000;
-final int iterationCount = 50;
+final int iterationCount = 100;
 
 final String dir = p.join('test', 'random_generator_test');
 String incorrectFilename = 'incorrect.html';
@@ -32,6 +32,7 @@ enum State {
 String genericExpression = ' + 1 + 2';
 
 List<NgSimpleTokenType> elementMap = <NgSimpleTokenType>[
+  NgSimpleTokenType.backSlash,
   NgSimpleTokenType.bang,
   NgSimpleTokenType.closeBanana,
   NgSimpleTokenType.closeBracket,
@@ -48,6 +49,7 @@ List<NgSimpleTokenType> elementMap = <NgSimpleTokenType>[
   NgSimpleTokenType.openBanana,
   NgSimpleTokenType.openBracket,
   NgSimpleTokenType.openParen,
+  NgSimpleTokenType.percent,
   NgSimpleTokenType.period,
   NgSimpleTokenType.singleQuote, //Special
   NgSimpleTokenType.star,

--- a/test/simple_tokenizer_test.dart
+++ b/test/simple_tokenizer_test.dart
@@ -160,6 +160,26 @@ void main() {
     ]);
   });
 
+  test(
+      'should tokenize an HTML element with bracket, period, percentage, and backSlash',
+      () {
+    expect(tokenize(r'''<div [style.he\ight.%>'''), [
+      new NgSimpleToken.openTagStart(0),
+      new NgSimpleToken.identifier(1, 'div'),
+      new NgSimpleToken.whitespace(4, ' '),
+      new NgSimpleToken.openBracket(5),
+      new NgSimpleToken.identifier(6, 'style'),
+      new NgSimpleToken.period(11),
+      new NgSimpleToken.identifier(12, 'he'),
+      new NgSimpleToken.backSlash(14),
+      new NgSimpleToken.identifier(15, 'ight'),
+      new NgSimpleToken.period(19),
+      new NgSimpleToken.percent(20),
+      new NgSimpleToken.tagEnd(21),
+      new NgSimpleToken.EOF(22),
+    ]);
+  });
+
   test('should tokenize an HTML element with banana open and close', () {
     expect(tokenize('''<my-tag [(banana)]>'''), [
       new NgSimpleToken.openTagStart(0),


### PR DESCRIPTION
Allow for parsing of % and backslash in css (or decorators in general). Needed because backslashes are allowed in css style syntax and % is allowed as well; example:
`<div [style.width.%]... >`

Error in incorrect usage will not be flagged here; ex: `<div blah%blah>`. This won't be flagged with any errors. This is intentional to allow more than legal into the syntax; a separate visitor can be made to go through these type of errors and flag improper usage of % and backslash.

Or, the application that utilizes this ast can flag is separately (ex: angular_analyzer_plugin is doing this).