### PR TITLE
use generic syntax without comments

### DIFF
--- a/lib/src/ast/attribute.dart
+++ b/lib/src/ast/attribute.dart
@@ -37,7 +37,7 @@ abstract class AttributeAst implements TemplateAst {
   ]) = ParsedAttributeAst;
 
   @override
-  /*=R*/ accept/*<R, C>*/(TemplateAstVisitor/*<R, C>*/ visitor, [C context]) {
+  R accept<R, C>(TemplateAstVisitor<R, C> visitor, [C context]) {
     return visitor.visitAttribute(this, context);
   }
 

--- a/lib/src/ast/close_element.dart
+++ b/lib/src/ast/close_element.dart
@@ -43,8 +43,8 @@ abstract class CloseElementAst implements TemplateAst {
   int get hashCode => name.hashCode;
 
   @override
-  R accept<R, C>(TemplateAstVisitor<R, C> visitor, [C context]) =>
-      visitor.visitCloseElement(this, context);
+  R accept<R, C>(TemplateAstVisitor<R, C> visitor, [C context]) => visitor
+      .visitCloseElement(this, context);
 
   /// Whether this is a `</template>` tag and should be directly rendered.
   bool get isEmbeddedTemplate => name == 'template';

--- a/lib/src/ast/close_element.dart
+++ b/lib/src/ast/close_element.dart
@@ -43,7 +43,7 @@ abstract class CloseElementAst implements TemplateAst {
   int get hashCode => name.hashCode;
 
   @override
-  /*=R*/ accept/*<R, C>*/(TemplateAstVisitor/*<R, C>*/ visitor, [C context]) =>
+  R accept<R, C>(TemplateAstVisitor<R, C> visitor, [C context]) =>
       visitor.visitCloseElement(this, context);
 
   /// Whether this is a `</template>` tag and should be directly rendered.

--- a/lib/src/ast/comment.dart
+++ b/lib/src/ast/comment.dart
@@ -29,7 +29,7 @@ abstract class CommentAst implements StandaloneTemplateAst {
   ) = _ParsedCommentAst;
 
   @override
-  /*=R*/ accept/*<R, C>*/(TemplateAstVisitor/*<R, C>*/ visitor, [C context]) {
+  R accept<R, C>(TemplateAstVisitor<R, C> visitor, [C context]) {
     return visitor.visitComment(this, context);
   }
 

--- a/lib/src/ast/content.dart
+++ b/lib/src/ast/content.dart
@@ -36,7 +36,7 @@ abstract class EmbeddedContentAst implements StandaloneTemplateAst {
   ]) = ParsedEmbeddedContentAst;
 
   @override
-  /*=R*/ accept/*<R, C>*/(TemplateAstVisitor/*<R, C>*/ visitor, [C context]) {
+  R accept<R, C>(TemplateAstVisitor<R, C> visitor, [C context]) {
     return visitor.visitEmbeddedContent(this, context);
   }
 

--- a/lib/src/ast/element.dart
+++ b/lib/src/ast/element.dart
@@ -90,7 +90,7 @@ abstract class ElementAst implements StandaloneTemplateAst {
   }
 
   @override
-  /*=R*/ accept/*<R, C>*/(TemplateAstVisitor/*<R, C>*/ visitor, [C context]) {
+  R accept<R, C>(TemplateAstVisitor<R, C> visitor, [C context]) {
     return visitor.visitElement(this, context);
   }
 

--- a/lib/src/ast/event.dart
+++ b/lib/src/ast/event.dart
@@ -52,7 +52,7 @@ abstract class EventAst implements TemplateAst {
   int get hashCode => hash3(name, expression, postfix);
 
   @override
-  /*=R*/ accept/*<R, C>*/(TemplateAstVisitor/*<R, C>*/ visitor, [C context]) {
+  R accept<R, C>(TemplateAstVisitor<R, C> visitor, [C context]) {
     return visitor.visitEvent(this, context);
   }
 

--- a/lib/src/ast/expression.dart
+++ b/lib/src/ast/expression.dart
@@ -42,7 +42,7 @@ class ExpressionAst implements TemplateAst {
   int get hashCode => expression.hashCode;
 
   @override
-  /*=R*/ accept/*<R, C>*/(TemplateAstVisitor/*<R, C>*/ visitor, [C context]) {
+  R accept<R, C>(TemplateAstVisitor<R, C> visitor, [C context]) {
     return visitor.visitExpression(this, context);
   }
 

--- a/lib/src/ast/interface.dart
+++ b/lib/src/ast/interface.dart
@@ -41,7 +41,7 @@ abstract class TemplateAst {
   }
 
   /// Have the [visitor] start visiting this node.
-  /*=R*/ accept/*<R, C>*/(TemplateAstVisitor/*<R, C>*/ visitor, [C context]);
+  R accept<R, C>(TemplateAstVisitor<R, C> visitor, [C context]);
 
   /// Whether this node is capable of containing children and does.
   ///

--- a/lib/src/ast/interpolation.dart
+++ b/lib/src/ast/interpolation.dart
@@ -30,7 +30,7 @@ abstract class InterpolationAst implements StandaloneTemplateAst {
   ) = ParsedInterpolationAst;
 
   @override
-  /*=R*/ accept/*<R, C>*/(TemplateAstVisitor/*<R, C>*/ visitor, [C context]) {
+  R accept<R, C>(TemplateAstVisitor<R, C> visitor, [C context]) {
     return visitor.visitInterpolation(this, context);
   }
 

--- a/lib/src/ast/property.dart
+++ b/lib/src/ast/property.dart
@@ -58,7 +58,7 @@ abstract class PropertyAst implements TemplateAst {
   int get hashCode => hash4(expression, name, postfix, unit);
 
   @override
-  /*=R*/ accept/*<R, C>*/(TemplateAstVisitor/*<R, C>*/ visitor, [C context]) {
+  R accept<R, C>(TemplateAstVisitor<R, C> visitor, [C context]) {
     return visitor.visitProperty(this, context);
   }
 

--- a/lib/src/ast/reference.dart
+++ b/lib/src/ast/reference.dart
@@ -47,7 +47,7 @@ abstract class ReferenceAst implements TemplateAst {
   int get hashCode => hash2(identifier, variable);
 
   @override
-  /*=R*/ accept/*<R, C>*/(TemplateAstVisitor/*<R, C>*/ visitor, [C context]) {
+  R accept<R, C>(TemplateAstVisitor<R, C> visitor, [C context]) {
     return visitor.visitReference(this, context);
   }
 

--- a/lib/src/ast/sugar/banana.dart
+++ b/lib/src/ast/sugar/banana.dart
@@ -40,7 +40,7 @@ abstract class BananaAst implements TemplateAst {
   ) = ParsedBananaAst;
 
   @override
-  /*=R*/ accept/*<R, C>*/(TemplateAstVisitor/*<R, C>*/ visitor, [C context]) {
+  R accept<R, C>(TemplateAstVisitor<R, C> visitor, [C context]) {
     return visitor.visitBanana(this, context);
   }
 

--- a/lib/src/ast/sugar/star.dart
+++ b/lib/src/ast/sugar/star.dart
@@ -39,7 +39,7 @@ abstract class StarAst implements TemplateAst {
   ]) = ParsedStarAst;
 
   @override
-  /*=R*/ accept/*<R, C>*/(TemplateAstVisitor/*<R, C>*/ visitor, [C context]) {
+  R accept<R, C>(TemplateAstVisitor<R, C> visitor, [C context]) {
     return visitor.visitStar(this, context);
   }
 

--- a/lib/src/ast/template.dart
+++ b/lib/src/ast/template.dart
@@ -49,7 +49,7 @@ abstract class EmbeddedTemplateAst implements StandaloneTemplateAst {
   }) = _ParsedEmbeddedTemplateAst;
 
   @override
-  /*=R*/ accept/*<R, C>*/(TemplateAstVisitor/*<R, C>*/ visitor, [C context]) {
+  R accept<R, C>(TemplateAstVisitor<R, C> visitor, [C context]) {
     return visitor.visitEmbeddedTemplate(this, context);
   }
 

--- a/lib/src/ast/text.dart
+++ b/lib/src/ast/text.dart
@@ -33,7 +33,7 @@ abstract class TextAst implements StandaloneTemplateAst {
   int get hashCode => value.hashCode;
 
   @override
-  /*=R*/ accept/*<R, C>*/(TemplateAstVisitor/*<R, C>*/ visitor, [C context]) {
+  R accept<R, C>(TemplateAstVisitor<R, C> visitor, [C context]) {
     return visitor.visitText(this, context);
   }
 

--- a/lib/src/expression/pipe.dart
+++ b/lib/src/expression/pipe.dart
@@ -52,7 +52,7 @@ class PipeExpression extends ExpressionImpl implements BinaryExpression {
   }
 
   @override
-  /*=E*/ accept/*<E>*/(AstVisitor/*<E>*/ visitor) {
+  E accept<E>(AstVisitor<E> visitor) {
     return visitor.visitBinaryExpression(this);
   }
 

--- a/lib/src/visitor.dart
+++ b/lib/src/visitor.dart
@@ -35,7 +35,7 @@ abstract class TemplateAstVisitor<R, C> {
   R visitEmbeddedTemplate(EmbeddedTemplateAst astNode, [C context]) {
     astNode
       ..attributes.forEach((a) => visitAttribute(a, context))
-      ..childNodes.forEach((c) => c.accept/*<R, C>*/(this, context))
+      ..childNodes.forEach((c) => c.accept<R, C>(this, context))
       ..properties.forEach((p) => visitProperty(p, context))
       ..references.forEach((r) => visitReference(r, context));
     return null;
@@ -45,7 +45,7 @@ abstract class TemplateAstVisitor<R, C> {
   R visitElement(ElementAst astNode, [C context]) {
     astNode
       ..attributes.forEach((a) => visitAttribute(a, context))
-      ..childNodes.forEach((c) => c.accept/*<R, C>*/(this, context))
+      ..childNodes.forEach((c) => c.accept<R, C>(this, context))
       ..events.forEach((e) => visitEvent(e, context))
       ..properties.forEach((p) => visitProperty(p, context))
       ..references.forEach((r) => visitReference(r, context));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: Parser and utilities for AngularDart templates
 version: 0.2.1-dev
 
 environment:
-  sdk: '>=1.20.0 <2.0.0'
+  sdk: '>=1.21.0 <2.0.0'
 
 dependencies:
   charcode: '^1.1.0'


### PR DESCRIPTION
Fixes #39 

Please note: minimum SDK requirement is now 1.21.0.