### PR TITLE
Raise error when identifier in attribute value is used without quotes

### DIFF
--- a/lib/src/exception_handler/exceptions.dart
+++ b/lib/src/exception_handler/exceptions.dart
@@ -18,6 +18,7 @@ const List<NgParserWarningCode> angularAstWarningCodes = const [
   NgParserWarningCode.ELEMENT_DECORATOR_AFTER_PREFIX,
   NgParserWarningCode.ELEMENT_DECORATOR_SUFFIX_BEFORE_PREFIX,
   NgParserWarningCode.ELEMENT_DECORATOR_VALUE,
+  NgParserWarningCode.ELEMENT_DECORATOR_VALUE_MISSING_QUOTES,
   NgParserWarningCode.ELEMENT_IDENTIFIER,
   NgParserWarningCode.EXPECTED_AFTER_ELEMENT_IDENTIFIER,
   NgParserWarningCode.EXPECTED_EQUAL_SIGN,
@@ -97,6 +98,12 @@ class NgParserWarningCode extends ErrorCode {
       const NgParserWarningCode(
     'ELEMENT_DECORATOR_VALUE',
     "Expected quoted value following '='",
+  );
+
+  static const NgParserWarningCode ELEMENT_DECORATOR_VALUE_MISSING_QUOTES =
+      const NgParserWarningCode(
+    'ELEMENT_DECORATOR_VALUE_MISSING_QUOTES',
+    'Decorator values must contain quotes',
   );
 
   static const NgParserWarningCode ELEMENT_IDENTIFIER =

--- a/lib/src/recovery_protocol/angular_analyzer_protocol.dart
+++ b/lib/src/recovery_protocol/angular_analyzer_protocol.dart
@@ -302,7 +302,6 @@ class NgAnalyzerRecoveryProtocol extends RecoveryProtocol {
         type == NgSimpleTokenType.EOF ||
         type == NgSimpleTokenType.equalSign ||
         type == NgSimpleTokenType.hash ||
-        type == NgSimpleTokenType.identifier ||
         type == NgSimpleTokenType.star) {
       reader.putBack(current);
       returnState = NgScannerState.scanAfterElementDecoratorValue;
@@ -313,6 +312,16 @@ class NgAnalyzerRecoveryProtocol extends RecoveryProtocol {
           offset, NgTokenType.elementDecoratorValue);
       var right =
           new NgToken.generateErrorSynthetic(offset, NgTokenType.doubleQuote);
+
+      returnToken = new NgAttributeValueToken.generate(left, value, right);
+    }
+    if (type == NgSimpleTokenType.identifier) {
+      returnState = NgScannerState.scanAfterElementDecoratorValue;
+      var left =
+          new NgToken.generateErrorSynthetic(offset, NgTokenType.doubleQuote);
+      var value = new NgToken.elementDecoratorValue(offset, current.lexeme);
+      var right = new NgToken.generateErrorSynthetic(
+          offset + current.length, NgTokenType.doubleQuote);
 
       returnToken = new NgAttributeValueToken.generate(left, value, right);
     }

--- a/lib/src/scanner.dart
+++ b/lib/src/scanner.dart
@@ -620,6 +620,14 @@ class NgScanner {
       return new NgToken.whitespace(_current.offset, _current.lexeme);
     }
 
+    if (type == NgSimpleTokenType.identifier) {
+      return handleError(
+        NgParserWarningCode.ELEMENT_DECORATOR_VALUE_MISSING_QUOTES,
+        _current.offset,
+        _current.length,
+      );
+    }
+
     if (type == NgSimpleTokenType.openBracket ||
         type == NgSimpleTokenType.openParen ||
         type == NgSimpleTokenType.openBanana ||
@@ -634,7 +642,6 @@ class NgScanner {
         type == NgSimpleTokenType.EOF ||
         type == NgSimpleTokenType.equalSign ||
         type == NgSimpleTokenType.hash ||
-        type == NgSimpleTokenType.identifier ||
         type == NgSimpleTokenType.star) {
       return handleError(
         NgParserWarningCode.ELEMENT_DECORATOR_VALUE,

--- a/test/recover_errors_lexer_test.dart
+++ b/test/recover_errors_lexer_test.dart
@@ -1058,8 +1058,9 @@ void elementDecoratorValue() {
     checkException(NgParserWarningCode.ELEMENT_DECORATOR_VALUE, 9, 1);
     expect(untokenize(tokenize('<div attr=#ref>')), '<div attr="" #ref>');
     checkException(NgParserWarningCode.ELEMENT_DECORATOR_VALUE, 9, 1);
-    expect(untokenize(tokenize('<div attr=attr2>')), '<div attr="" attr2>');
-    checkException(NgParserWarningCode.ELEMENT_DECORATOR_VALUE, 9, 1);
+    expect(untokenize(tokenize('<div attr=attr2>')), '<div attr="attr2">');
+    checkException(
+        NgParserWarningCode.ELEMENT_DECORATOR_VALUE_MISSING_QUOTES, 10, 5);
     expect(untokenize(tokenize('<div attr=*temp>')), '<div attr="" *temp>');
     checkException(NgParserWarningCode.ELEMENT_DECORATOR_VALUE, 9, 1);
 


### PR DESCRIPTION
Usage of identifier in attribute value will now flag specific error of missing quotes. 
Ex: `<div [someInput]=blah>`