### PR TITLE
Accept any amount of event suffixes, ie keyup.ctrl.shift.enter etc

### DIFF
--- a/lib/src/ast/event.dart
+++ b/lib/src/ast/event.dart
@@ -69,7 +69,7 @@ abstract class EventAst implements TemplateAst {
   /// Unquoted value being bound to event.
   String get value;
 
-  /// An optional set of postfixes used to filter events that support it.
+  /// An optional list of postfixes used to filter events that support it.
   ///
   /// For example `(keydown.ctrl.space)`.
   List<String> get reductions;
@@ -77,7 +77,7 @@ abstract class EventAst implements TemplateAst {
   @override
   String toString() {
     if (reductions.isNotEmpty) {
-      return '$EventAst {$name.$reductions="$value", Expression=$expression}';
+      return '$EventAst {$name.${reductions.join(',')}="$value", Expression=$expression}';
     }
     return '$EventAst {$name=$value, Expression=$expression}';
   }
@@ -164,11 +164,11 @@ class ParsedEventAst extends TemplateAst
   @override
   int get suffixOffset => suffixToken.offset;
 
-  /// Name `filters` in `(eventName.ctrl.shift.a)`; may be empty.
+  /// Name `reductions` in `(eventName.ctrl.shift.a)`; may be empty.
   @override
   List<String> get reductions {
     final split = _nameWithoutParentheses.split('.');
-    return split.getRange(1, split.length).toList();
+    return split.sublist(1);
   }
 }
 

--- a/lib/src/ast/event.dart
+++ b/lib/src/ast/event.dart
@@ -5,10 +5,13 @@
 import 'package:angular_ast/src/ast.dart';
 import 'package:angular_ast/src/token/tokens.dart';
 import 'package:angular_ast/src/visitor.dart';
+import 'package:collection/collection.dart';
 import 'package:source_span/source_span.dart';
 import 'package:quiver/core.dart';
 
-/// Represents an event listener `(eventName.postfix)="expression"` on an
+const _listEquals = const ListEquality<dynamic>();
+
+/// Represents an event listener `(eventName.reductions)="expression"` on an
 /// element.
 ///
 /// Clients should not extend, implement, or mix-in this class.
@@ -18,7 +21,7 @@ abstract class EventAst implements TemplateAst {
     String name,
     String value, [
     ExpressionAst expression,
-    String postfix,
+    List<String> reductions,
   ]) = _SyntheticEventAst;
 
   /// Create a new synthetic [EventAst] that originated from [origin].
@@ -27,7 +30,7 @@ abstract class EventAst implements TemplateAst {
     String name,
     String value, [
     ExpressionAst expression,
-    String postfix,
+    List<String> reductions,
   ]) = _SyntheticEventAst.from;
 
   /// Create a new [EventAst] parsed from tokens in [sourceFile].
@@ -46,10 +49,10 @@ abstract class EventAst implements TemplateAst {
       o is EventAst &&
       name == o.name &&
       expression == o.expression &&
-      postfix == o.postfix;
+      _listEquals.equals(reductions, o.reductions);
 
   @override
-  int get hashCode => hash3(name, expression, postfix);
+  int get hashCode => hash3(name, expression, reductions);
 
   @override
   R accept<R, C>(TemplateAstVisitor<R, C> visitor, [C context]) {
@@ -66,15 +69,15 @@ abstract class EventAst implements TemplateAst {
   /// Unquoted value being bound to event.
   String get value;
 
-  /// An optional postfix used to filter events that support it.
+  /// An optional set of postfixes used to filter events that support it.
   ///
-  /// For example `(keydown.space)`.
-  String get postfix;
+  /// For example `(keydown.ctrl.space)`.
+  List<String> get reductions;
 
   @override
   String toString() {
-    if (postfix != null) {
-      return '$EventAst {$name.$postfix="$value", Expression=$expression}';
+    if (reductions.isNotEmpty) {
+      return '$EventAst {$name.$reductions="$value", Expression=$expression}';
     }
     return '$EventAst {$name=$value, Expression=$expression}';
   }
@@ -129,7 +132,7 @@ class ParsedEventAst extends TemplateAst
   @override
   ExpressionAst expression;
 
-  /// Name `eventName` in `(eventName.postfix)`.
+  /// Name `eventName` in `(eventName.reductions)`.
   @override
   String get name => _nameWithoutParentheses.split('.').first;
 
@@ -153,20 +156,19 @@ class ParsedEventAst extends TemplateAst
   @override
   int get quotedValueOffset => valueToken?.leftQuote?.offset;
 
-  /// Offset of `(` prefix in `(eventName.postfix)`.
+  /// Offset of `(` prefix in `(eventName.reductions)`.
   @override
   int get prefixOffset => prefixToken.offset;
 
-  /// Offset of `)` suffix in `(eventName.postfix)`.
+  /// Offset of `)` suffix in `(eventName.reductions)`.
   @override
   int get suffixOffset => suffixToken.offset;
 
-  /// Name `postfix` in `(eventName.postfix)`; may be `null` to have no value.
+  /// Name `filters` in `(eventName.ctrl.shift.a)`; may be empty.
   @override
-  String get postfix {
+  List<String> get reductions {
     final split = _nameWithoutParentheses.split('.');
-    assert(split.length < 2);
-    return split.length > 1 ? split[1] : null;
+    return split.getRange(1, split.length).toList();
   }
 }
 
@@ -181,13 +183,13 @@ class _SyntheticEventAst extends SyntheticTemplateAst with EventAst {
   ExpressionAst expression;
 
   @override
-  final String postfix;
+  final List<String> reductions;
 
   _SyntheticEventAst(
     this.name,
     this.value, [
     this.expression,
-    this.postfix,
+    this.reductions = const [],
   ]);
 
   _SyntheticEventAst.from(
@@ -195,7 +197,7 @@ class _SyntheticEventAst extends SyntheticTemplateAst with EventAst {
     this.name,
     this.value, [
     this.expression,
-    this.postfix,
+    this.reductions = const [],
   ])
       : super.from(origin);
 }

--- a/lib/src/parser/recursive.dart
+++ b/lib/src/parser/recursive.dart
@@ -133,13 +133,15 @@ class RecursiveAstParser {
           equalSignToken,
         );
       } else if (prefixType == NgTokenType.eventPrefix) {
-        if (decoratorToken.lexeme.split('.').length > 2) {
-          exceptionHandler.handle(new AngularParserException(
-            NgParserWarningCode.EVENT_NAME_TOO_MANY_FIXES,
-            decoratorToken.offset,
-            decoratorToken.length,
-          ));
-        }
+        // Disabling: event names can be as long as keyup.ctrl.shift.alt.mod.+
+        // Should this be limited to 6 then? Or should it be left open?
+        //if (decoratorToken.lexeme.split('.').length > 2) {
+        //  exceptionHandler.handle(new AngularParserException(
+        //    NgParserWarningCode.EVENT_NAME_TOO_MANY_FIXES,
+        //    decoratorToken.offset,
+        //    decoratorToken.length,
+        //  ));
+        //}
 
         return new EventAst.parsed(
           _source,

--- a/lib/src/visitors/humanizing.dart
+++ b/lib/src/visitors/humanizing.dart
@@ -145,8 +145,8 @@ class HumanizingTemplateAstVisitor
   String visitEvent(EventAst astNode, [StringBuffer context]) {
     context ??= new StringBuffer();
     context.write('(${astNode.name}');
-    if (astNode.postfix != null) {
-      context.write('.${astNode.postfix}');
+    if (astNode.reductions.isNotEmpty) {
+      context.write('.${astNode.reductions.join(".")}');
     }
     context.write(')');
     if (astNode.value != null) {

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -171,7 +171,8 @@ void main() {
                 'onClick()',
                 19,
                 sourceUrl: '/test/expression/parser_test.dart#inline',
-              )),
+              ),
+              []),
         ]),
       ],
     );


### PR DESCRIPTION
Decided to call the "reductions", for no real good reason. Basically,
they filter down the events, but "filter" sounded to me like something
to linear -- ie, keyup.ctrl.a should be a filter of keyup.a, but that's
not the case. For whatever reason, I felt like reductions didn't imply
this while still being a synonym of filter.

We *could* enforce a, say, 6 limit based on the current modifiers etc
that are allowed for keyup, but that seems arbitrary.

Alternatively, we could try to parse keyup/down modifiers and keys
directly in the ast, rather than leaving it as an array of strings.
That's probably the best long term option.

At the very least, this will allow us to, in the plugin, support
keyup.foo.bar.baz rather than report it as an error. Later on we can
try to validate it in either place, once we've solved the false errors.