### PR TITLE
Remove assertions. Not sure if they should be exceptions.

### DIFF
--- a/lib/src/ast/property.dart
+++ b/lib/src/ast/property.dart
@@ -191,7 +191,6 @@ class ParsedPropertyAst extends TemplateAst
   @override
   String get postfix {
     final split = _nameWithoutBrackets.split('.');
-    assert(split.length < 3);
     return split.length > 1 ? split[1] : null;
   }
 
@@ -199,7 +198,6 @@ class ParsedPropertyAst extends TemplateAst
   @override
   String get unit {
     final split = _nameWithoutBrackets.split('.');
-    assert(split.length < 3);
     return split.length > 2 ? split[2] : null;
   }
 }


### PR DESCRIPTION
I remember trying to think out the best thing to do here. It might even
have been my suggestion for all I remember, to put the asserts here.
    
However, this makes tests fail inside the analyzer in "checked mode",
which we should be using. Strictly speaking, asserts should only assert
against the impossible -- that which, if it fails, should fail any and
all tests. But I want to test the error condition here, and the
recovery, so there should be a way for such a test to fail what this
assertion is testing against, and still have that test pass.
    
Checked mode is important because it ensures that the type annotations
are accurate and that we aren't failing our own assertions, and, to a
lesser extent, failing asserts in other libs like the analyzer.
    
Now, the assert makes sense here from the perspective of "This
operation has no real answer, you shouldn't do this." However, its not
simple for API consumers to check *when* that's the case. We'd have to
either analyze `attrName.lexeme.split('.')` myself, or we'd have to
track when errors are reported, and somehow correlate that to the
property asts that are produced.
    
This makes me think that what we want is an exception....however, we
don't really want an exception either, in the analyzer's case. We want
to be able to get an answer, with some kind of error recovery.
    
So for now, I'm just removing, but open to the discussion of what
*should be done*.